### PR TITLE
feat: Add microsoft.com

### DIFF
--- a/lib/html2rss/configs/microsoft.com/azure-products.yml
+++ b/lib/html2rss/configs/microsoft.com/azure-products.yml
@@ -1,6 +1,8 @@
 channel:
   url: https://azure.microsoft.com/en-us/products
   language: en
+  time_zone: US/Pacific
+  ttl: 3600
 selectors:
   items:
     selector: ".card-body"


### PR DESCRIPTION
Add the selectors for Azure's product overview page.

Tested with html2rss `v0.17.0`, installed via gem install, in a latest `ruby:3.4` container.

**Please note**: As indicated in the yaml, the `url` configuration setting did not work for me as documented. I had to use `link` to actually produce a RSS feed with article links. I acknowledge the yaml files for the other sites do have `url` statements as well, so it's either a bug with the `html2rss` version I use or an undiscovered bug that did not surface for some reason.