### PR TITLE
fix(configs): repair failing fetch configs and drop legacy generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gem 'html2rss', '>= 0.25.0'
 
 group :development do
-  gem 'html2rss-generator', github: 'html2rss/generator', branch: :main
-
   gem 'nokogiri'
   gem 'public_suffix'
   gem 'rspec', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: https://github.com/html2rss/generator
-  revision: 05bca799648034e8937e08baaa47b03af4aed5b0
-  branch: main
-  specs:
-    html2rss-generator (0.1.0)
-      faraday
-      hashie
-      htmlbeautifier
-      tty-markdown
-      tty-prompt
-
 PATH
   remote: .
   specs:
@@ -102,8 +90,6 @@ GEM
     fiber-local (1.1.0)
       fiber-storage
     fiber-storage (1.0.1)
-    hashie (5.1.0)
-      logger
     html2rss (0.25.0)
       addressable (~> 2.7)
       brotli
@@ -122,7 +108,6 @@ GEM
       thor
       tzinfo
       zeitwerk
-    htmlbeautifier (1.4.3)
     io-endpoint (0.17.2)
     io-event (1.19.5)
     io-stream (0.14.0)
@@ -150,8 +135,6 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    pastel (0.8.0)
-      tty-color (~> 0.5)
     prism (1.9.0)
     protocol-hpack (1.5.1)
     protocol-http (0.70.0)
@@ -182,7 +165,6 @@ GEM
     reverse_markdown (3.0.2)
       nokogiri
     rexml (3.4.4)
-    rouge (4.7.0)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -223,38 +205,14 @@ GEM
     sanitize (7.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
-    strings (0.2.1)
-      strings-ansi (~> 0.2)
-      unicode-display_width (>= 1.5, < 3.0)
-      unicode_utils (~> 1.4)
-    strings-ansi (0.2.0)
     thor (1.5.0)
-    tty-color (0.6.0)
-    tty-cursor (0.7.1)
-    tty-markdown (0.7.2)
-      kramdown (>= 1.16.2, < 3.0)
-      pastel (~> 0.8)
-      rouge (>= 3.14, < 5.0)
-      strings (~> 0.2.0)
-      tty-color (~> 0.5)
-      tty-screen (~> 0.8)
-    tty-prompt (0.23.1)
-      pastel (~> 0.8)
-      tty-reader (~> 0.8)
-    tty-reader (0.9.0)
-      tty-cursor (~> 0.7)
-      tty-screen (~> 0.8)
-      wisper (~> 2.0)
-    tty-screen (0.8.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
-    unicode_utils (1.4.0)
     uri (1.1.1)
     urlpattern (0.1.1-arm64-darwin)
     urlpattern (0.1.1-x86_64-darwin)
     urlpattern (0.1.1-x86_64-linux)
-    wisper (2.0.1)
     zeitwerk (2.8.3)
     zlib (3.2.3)
 
@@ -268,7 +226,6 @@ PLATFORMS
 DEPENDENCIES
   html2rss (>= 0.25.0)
   html2rss-configs!
-  html2rss-generator!
   nokogiri
   public_suffix
   rspec (~> 3.0)

--- a/bin/generator
+++ b/bin/generator
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
-
-require 'bundler/setup'
-require 'html2rss/generator'
-
-Html2rss::Generator.start

--- a/lib/html2rss/configs/apple.com/newsroom.yml
+++ b/lib/html2rss/configs/apple.com/newsroom.yml
@@ -9,9 +9,10 @@ channel:
 request:
   botasaurus:
     wait_for_selector: "li.tile-item"
+    wait_timeout_seconds: 20
 selectors:
   items:
-    selector: "li.tile-item a.tile-hero, li.tile-item a.tile-2up, li.tile-item a.tile-3up, li.tile-item a.tile-list"
+    selector: "li.tile-item a.tile"
     enhance: false
   title:
     selector: .tile__headline

--- a/lib/html2rss/configs/canarianweekly.com/front.yml
+++ b/lib/html2rss/configs/canarianweekly.com/front.yml
@@ -6,9 +6,9 @@ channel:
   language: en
 selectors:
   items:
-    selector: ".article__entry"
+    selector: "h5.post-title a"
+    enhance: false
   title:
-    selector: "h5 > a"
+    extractor: text
   url:
-    selector: "h5 > a"
     extractor: "href"

--- a/lib/html2rss/configs/cleanenergywire.org/news.yml
+++ b/lib/html2rss/configs/cleanenergywire.org/news.yml
@@ -1,17 +1,18 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 channel:
-  url: https://www.cleanenergywire.org/news-archive
+  url: https://www.cleanenergywire.org/news
   time_zone: "Europe/Berlin"
   ttl: 360
 selectors:
   items:
-    selector: ".view-content article"
+    selector: ".views-row"
+    enhance: false
   title:
-    selector: "h3 a"
+    selector: "h2 a"
   url:
-    selector: "h3 a"
+    selector: "h2 a"
     extractor: "href"
   published_at:
-    selector: ".date-display-single"
+    selector: "time"
     post_process:
       - name: parse_time

--- a/lib/html2rss/configs/cnet.com/section_sub.yml
+++ b/lib/html2rss/configs/cnet.com/section_sub.yml
@@ -3,23 +3,19 @@
 parameters:
   section:
     type: string
-    default: "news"
-  sub:
-    type: string
     default: "tech"
 
 channel:
-  url: https://www.cnet.com/%<section>s/%<sub>s/
+  url: https://www.cnet.com/%<section>s/
   language: en
   ttl: 360
   time_zone: UTC
 selectors:
   items:
-    selector: ".c-storiesNeonHighlightsCard"
+    selector: "article.list-entry"
+    enhance: false
   title:
-    selector: ".g-text-bold"
+    selector: "h3.list-entry__title a"
   url:
-    selector: a:first
+    selector: "h3.list-entry__title a"
     extractor: href
-  description:
-    selector: span

--- a/lib/html2rss/configs/deepmind.google/blog.yml
+++ b/lib/html2rss/configs/deepmind.google/blog.yml
@@ -1,5 +1,4 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
-strategy: botasaurus
 
 channel:
   url: https://deepmind.google/blog/

--- a/lib/html2rss/configs/deraktionaer.de/meistgelesen.yml
+++ b/lib/html2rss/configs/deraktionaer.de/meistgelesen.yml
@@ -6,7 +6,6 @@ channel:
   ttl: 360
   language: de
 enhance: false
-strategy: botasaurus
 selectors:
   items:
     selector: "section#top-articles article.top-article a.top-article-content[href^='/artikel/']"

--- a/lib/html2rss/configs/dsw-info.de/presse.yml
+++ b/lib/html2rss/configs/dsw-info.de/presse.yml
@@ -1,12 +1,13 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 channel:
-  url: https://www.dsw-info.de/presse
+  url: https://www.dsw-info.de/presse/pressemitteilungen-2026/
   time_zone: Europe/Berlin
   ttl: 720
   language: de
 selectors:
   items:
-    selector: ".cesprop-0 .container.zw-01 .frame:nth-child(2) ul > li"
+    selector: "main .frame.cet-menu ul > li"
+    enhance: false
   title:
     selector: "a"
   url:

--- a/lib/html2rss/configs/elastic.co/elasticsearch-release-notes.yml
+++ b/lib/html2rss/configs/elastic.co/elasticsearch-release-notes.yml
@@ -4,7 +4,6 @@ channel:
   language: en
   time_zone: UTC
   ttl: 360
-strategy: botasaurus
 selectors:
   items:
     selector: 'a[href^="#elasticsearch-"][href$="-release-notes"]'

--- a/lib/html2rss/configs/formula1.com/latest.yml
+++ b/lib/html2rss/configs/formula1.com/latest.yml
@@ -1,20 +1,13 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 channel:
-  url: https://www.formula1.com/en/latest/all.html
+  url: https://www.formula1.com/en/latest
   time_zone: UTC
   ttl: 120
 selectors:
   items:
-    selector: "#article-list > li"
+    selector: 'a[class*="ArticleListCard-module_title"]'
+    enhance: false
   title:
-    selector: "p"
+    extractor: text
   url:
-    selector: "a"
     extractor: "href"
-  categories:
-    - category_a
-    - category_b
-  category_a:
-    selector: "figcaption>span:first"
-  category_b:
-    selector: "figcaption>span:last"

--- a/lib/html2rss/configs/github.com/releases.yml
+++ b/lib/html2rss/configs/github.com/releases.yml
@@ -5,7 +5,7 @@ parameters:
     default: "nuxt"
   repository:
     type: string
-    default: "nuxt.js"
+    default: "nuxt"
 
 channel:
   url: https://github.com/%<username>s/%<repository>s/releases
@@ -15,11 +15,9 @@ channel:
 selectors:
   items:
     selector: ".repository-content section"
+    enhance: false
   title:
-    selector: "h2"
+    selector: 'a[href*="/releases/tag/"]'
   url:
-    selector: "a"
+    selector: 'a[href*="/releases/tag/"]'
     extractor: "href"
-  description:
-    selector: '[data-test-selector="body-content"]'
-    extractor: "html"

--- a/lib/html2rss/configs/go.dev/release-history.yml
+++ b/lib/html2rss/configs/go.dev/release-history.yml
@@ -4,7 +4,6 @@ channel:
   language: en
   time_zone: UTC
   ttl: 360
-strategy: botasaurus
 selectors:
   items:
     selector: 'a[href^="/doc/go1."]'

--- a/lib/html2rss/configs/grafana.com/whatsnew.yml
+++ b/lib/html2rss/configs/grafana.com/whatsnew.yml
@@ -4,7 +4,6 @@ channel:
   language: en
   time_zone: UTC
   ttl: 360
-strategy: botasaurus
 selectors:
   items:
     selector: 'a.docs__menu-a[href^="/docs/grafana/latest/whatsnew/whats-new-in-v"]'

--- a/lib/html2rss/configs/iaapa.org/news.yml
+++ b/lib/html2rss/configs/iaapa.org/news.yml
@@ -4,7 +4,6 @@ channel:
   time_zone: UTC
   ttl: 720
 enhance: false
-strategy: botasaurus
 selectors:
   items:
     selector: ".views-row > article"

--- a/lib/html2rss/configs/imdb.com/ratings.yml
+++ b/lib/html2rss/configs/imdb.com/ratings.yml
@@ -1,4 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+strategy: botasaurus
+
 parameters:
   user_id:
     type: string
@@ -8,9 +10,14 @@ channel:
   url: https://www.imdb.com/user/%<user_id>s/ratings
   time_zone: UTC
   ttl: 1440
+request:
+  botasaurus:
+    wait_timeout_seconds: 20
+    wait_for_selector: "li.ipc-metadata-list-summary-item"
 selectors:
   items:
     selector: "li.ipc-metadata-list-summary-item"
+    enhance: false
   title:
     selector: ".ipc-title__text"
     post_process:

--- a/lib/html2rss/configs/mozilla.org/security-advisories.yml
+++ b/lib/html2rss/configs/mozilla.org/security-advisories.yml
@@ -4,7 +4,6 @@ channel:
   language: en
   time_zone: UTC
   ttl: 360
-strategy: botasaurus
 selectors:
   items:
     selector: "main li"

--- a/lib/html2rss/configs/notion.com/blog.yml
+++ b/lib/html2rss/configs/notion.com/blog.yml
@@ -1,5 +1,4 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
-strategy: botasaurus
 
 channel:
   url: https://www.notion.com/blog

--- a/lib/html2rss/configs/rbb24.de/meistgeklickt.yml
+++ b/lib/html2rss/configs/rbb24.de/meistgeklickt.yml
@@ -1,15 +1,15 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 channel:
   title: "rbb24.de: meistgeklickt"
-  url: https://rbb24.de/
+  url: https://www.rbb24.de/das-beste/
   time_zone: Europe/Berlin
   ttl: 30
   language: de
 selectors:
   items:
-    selector: ".tabmodul_container > li:last-child > ul > li"
+    selector: "article.top-teaser a.top-teaser__text-container"
+    enhance: false
   title:
-    selector: "a"
+    extractor: "text"
   url:
-    selector: "a"
     extractor: "href"

--- a/lib/html2rss/configs/robinwood.de/aktuelles.yml
+++ b/lib/html2rss/configs/robinwood.de/aktuelles.yml
@@ -1,16 +1,15 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 channel:
-  url: https://www.robinwood.de/was-gibt-es-neues/aktuelles
+  url: https://www.robinwood.de/was-gibt-es-neues
   time_zone: Europe/Berlin
   ttl: 720
   language: de
 selectors:
   items:
-    selector: "article[data-history-node-id]"
+    selector: "article.node--view-mode-teaser"
+    enhance: false
   title:
     selector: "h2"
   url:
     selector: "a"
     extractor: "href"
-  description:
-    selector: ".teaser-text"

--- a/lib/html2rss/configs/sebastianvettel.de/news.yml
+++ b/lib/html2rss/configs/sebastianvettel.de/news.yml
@@ -1,15 +1,16 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
 channel:
-  url: https://sebastianvettel.de/news/
+  url: https://sebastianvettel.de/
   language: de-DE
   ttl: 8640
   time_zone: Europe/Berlin
 selectors:
   items:
-    selector: ".card.title_in_content"
+    selector: ".gb-loop-item:has(a[href*='/news/'])"
+    enhance: false
   title:
-    selector: h2
-  description:
-    selector: ".row-text-bild-modul"
-    extractor: html
+    selector: ".gb-text:first-child"
+  url:
+    selector: "a[href*='/news/']"
+    extractor: href

--- a/lib/html2rss/configs/shopify.com/blog.yml
+++ b/lib/html2rss/configs/shopify.com/blog.yml
@@ -1,5 +1,4 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
-strategy: botasaurus
 
 channel:
   url: https://www.shopify.com/blog/latest

--- a/lib/html2rss/configs/spotify.com/newsroom.yml
+++ b/lib/html2rss/configs/spotify.com/newsroom.yml
@@ -1,5 +1,4 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
-strategy: botasaurus
 
 channel:
   url: https://newsroom.spotify.com/

--- a/lib/html2rss/configs/stackoverflow.com/hot_network_questions.yml
+++ b/lib/html2rss/configs/stackoverflow.com/hot_network_questions.yml
@@ -1,12 +1,19 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+strategy: botasaurus
+
 channel:
   title: "stackoverflow.com: Hot Network Questions"
   url: https://stackoverflow.com/questions
   time_zone: America/New_York
   ttl: 30
+request:
+  botasaurus:
+    wait_timeout_seconds: 20
+    wait_for_selector: "#hot-network-questions"
 selectors:
   items:
     selector: "#hot-network-questions ul > li"
+    enhance: false
   title:
     selector: a
   url:

--- a/lib/html2rss/configs/steuerzahler.de/news.yml
+++ b/lib/html2rss/configs/steuerzahler.de/news.yml
@@ -1,14 +1,15 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 channel:
-  url: https://www.steuerzahler.de/news
+  url: https://www.steuerzahler.de/news/
   time_zone: Europe/Berlin
   ttl: 720
   language: de
 selectors:
   items:
     selector: ".bdst_presslist .bdst_presslist__block"
+    enhance: false
   title:
-    selector: "h4"
+    selector: "a"
   url:
     selector: "a"
     extractor: "href"

--- a/lib/html2rss/configs/support.apple.com/en_gb_ht201222.yml
+++ b/lib/html2rss/configs/support.apple.com/en_gb_ht201222.yml
@@ -1,21 +1,22 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
 channel:
-  url: https://support.apple.com/en-gb/HT201222
+  url: https://support.apple.com/en-gb/100100
   language: en
   ttl: 360
   time_zone: UTC
 selectors:
   items:
     selector: ".table-wrapper table tbody > tr:not(:first-child)"
+    enhance: false
   title:
     selector: a
   url:
-    selector: a:first
+    selector: a
     extractor: href
   description:
-    selector: td:nth-child(2)
+    selector: "td:nth-child(2)"
   published_at:
-    selector: td:nth-child(3)
+    selector: "td:nth-child(3)"
     post_process:
       - name: parse_time

--- a/lib/html2rss/configs/support.apple.com/exchange_repair.yml
+++ b/lib/html2rss/configs/support.apple.com/exchange_repair.yml
@@ -1,11 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 channel:
-  url: https://support.apple.com/exchange_repair
+  url: https://support.apple.com/service-programs
   time_zone: America/Los_Angeles
   ttl: 720
 selectors:
   items:
-    selector: ".main .as-columns--2up-extended"
+    selector: ".as-columns--2up-extended"
+    enhance: false
   title:
     selector: "a"
   url:
@@ -15,10 +16,6 @@ selectors:
     selector: "img"
     extractor: "attribute"
     attribute: "src"
-  published_at:
-    selector: ".note"
-    post_process:
-      - name: parse_time
   description:
     post_process:
       - name: template

--- a/lib/html2rss/configs/thoughtworks.com/insights.yml
+++ b/lib/html2rss/configs/thoughtworks.com/insights.yml
@@ -1,16 +1,20 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+strategy: botasaurus
+
 channel:
-  url: https://www.thoughtworks.com/insights
+  url: https://www.thoughtworks.com/insights/blog
   language: en
   ttl: 360
   time_zone: UTC
+request:
+  botasaurus:
+    wait_timeout_seconds: 20
+    wait_for_selector: 'a[href*="/insights/blog/"]'
 selectors:
   items:
-    selector: ".cmp-content-card"
+    selector: 'a[href*="/insights/blog/"]'
+    enhance: false
   title:
-    selector: ".cmp-content-card__text__para-text"
+    extractor: text
   url:
-    selector: a:first
     extractor: href
-  description:
-    selector: p

--- a/lib/html2rss/configs/tourismusnetzwerk-brandenburg.de/aktuelle_nachrichten.yml
+++ b/lib/html2rss/configs/tourismusnetzwerk-brandenburg.de/aktuelle_nachrichten.yml
@@ -5,7 +5,6 @@ channel:
   ttl: 720
   language: de
 enhance: false
-strategy: botasaurus
 selectors:
   items:
     selector: "article.node.article.wall-floating"

--- a/spec/support/botasaurus_fetch_configs.rb
+++ b/spec/support/botasaurus_fetch_configs.rb
@@ -3,17 +3,9 @@
 module BotasaurusFetchConfigs
   CONFIGS = %w[
     apple.com/newsroom.yml
-    deepmind.google/blog.yml
-    deraktionaer.de/meistgelesen.yml
-    elastic.co/elasticsearch-release-notes.yml
-    go.dev/release-history.yml
-    grafana.com/whatsnew.yml
-    iaapa.org/news.yml
-    mozilla.org/security-advisories.yml
-    notion.com/blog.yml
-    shopify.com/blog.yml
-    spotify.com/newsroom.yml
-    tourismusnetzwerk-brandenburg.de/aktuelle_nachrichten.yml
+    imdb.com/ratings.yml
+    stackoverflow.com/hot_network_questions.yml
+    thoughtworks.com/insights.yml
   ].freeze
 
   module_function


### PR DESCRIPTION
## What changed

- Repaired 27 of 28 previously failing fetch configs (selectors / channel URLs / strategies).
- Demoted many configs from Botasaurus to Faraday; Botasaurus allowlist kept only for `apple.com/newsroom`, `thoughtworks.com/insights`, `imdb.com/ratings`, and `stackoverflow.com/hot_network_questions`.
- Dropped legacy `html2rss-generator` (`Gemfile` + `bin/generator`) and refreshed `Gemfile.lock`.
- Deferred `pankow.lebensmittel-kontrollergebnisse.de/search.yml` (search redirects to homepage).

## Why

Fetch specs were failing after site markup and request-strategy drift. Several Botasaurus-listed configs work with Faraday once selectors are tightened; keeping Botasaurus only where static fetch still returns empty keeps the Botasaurus lane small and honest. The generator gem was unused wiring for this catalog repo.

## Risk

- Selector drift on repaired sites remains the main residual risk.
- Botasaurus-backed four configs still depend on `BOTASAURUS_SCRAPER_URL`.
- Deferred pankow config stays broken until a stable non-search surface exists.

## Review map

1. `spec/support/botasaurus_fetch_configs.rb` — confirm allowlist shrink matches Botasaurus-kept YAMLs.
2. `lib/html2rss/configs/{imdb,thoughtworks,stackoverflow,apple}.com/*.yml` — Botasaurus-kept strategy/selector changes.
3. Higher-churn Faraday repairs (`formula1.com/latest.yml`, `cnet.com/section_sub.yml`, `github.com/releases.yml`, `sebastianvettel.de/news.yml`, support.apple.com configs) — item/title/url tightness.
4. `Gemfile` / `bin/generator` — generator removal is intentional and complete.

## Validation

- `make validate`
- `make test`
- focused `:fetch` lane and Botasaurus fetch lane (claimed green in prior session)