### PR TITLE
fix(configs): Botasaurus-back Apple HT security releases

### DIFF
--- a/lib/html2rss/configs/rbb24.de/meistgeklickt.yml
+++ b/lib/html2rss/configs/rbb24.de/meistgeklickt.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 channel:
-  title: "rbb24.de: meistgeklickt"
+  title: "rbb24.de: Das Beste"
   url: https://www.rbb24.de/das-beste/
   time_zone: Europe/Berlin
   ttl: 30

--- a/lib/html2rss/configs/support.apple.com/en_gb_ht201222.yml
+++ b/lib/html2rss/configs/support.apple.com/en_gb_ht201222.yml
@@ -1,10 +1,16 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+strategy: botasaurus
+
 channel:
   url: https://support.apple.com/en-gb/100100
   language: en
   ttl: 360
   time_zone: UTC
+request:
+  botasaurus:
+    wait_for_selector: ".table-wrapper table tbody tr a"
+    wait_timeout_seconds: 20
 selectors:
   items:
     selector: ".table-wrapper table tbody > tr:not(:first-child)"

--- a/spec/support/botasaurus_fetch_configs.rb
+++ b/spec/support/botasaurus_fetch_configs.rb
@@ -5,6 +5,7 @@ module BotasaurusFetchConfigs
     apple.com/newsroom.yml
     imdb.com/ratings.yml
     stackoverflow.com/hot_network_questions.yml
+    support.apple.com/en_gb_ht201222.yml
     thoughtworks.com/insights.yml
   ].freeze
 


### PR DESCRIPTION
## What changed

- `support.apple.com/en_gb_ht201222.yml`: set `strategy: botasaurus` with `wait_for_selector` / `wait_timeout_seconds: 20`
- Registered the config in `spec/support/botasaurus_fetch_configs.rb`
- `rbb24.de/meistgeklickt.yml`: align `channel.title` with `/das-beste/` surface (`rbb24.de: Das Beste`)

## Why

### Root cause

Faraday requests to Apple Support land on verify-human / bot challenge HTML, so the HT security-releases table selectors match nothing (0 items). Botasaurus renders the real table.

Follow-up to #308 (merged; `test_changed_configs` had failed on this surface).

## Risk

- Low — Apple HT now depends on Botasaurus like other bot-sensitive configs
- Residual: Apple may still challenge some Botasaurus runs; selectors unchanged and already verified live

## Review map

Review map: whole PR is small — start at `lib/html2rss/configs/support.apple.com/en_gb_ht201222.yml`.

## Validation

- `/Users/gil/.local/share/mise/installs/ruby/4.0.6/bin/html2rss validate …/en_gb_ht201222.yml` → exit 0
- `BOTASAURUS_SCRAPER_URL=http://localhost:4010` + same binary `feed …/en_gb_ht201222.yml` → exit 0, 240 `<item>`s
- `BOTASAURUS_SCRAPER_URL=http://localhost:4010 mise exec -- bundle exec rspec --tag fetch --example 'support.apple.com/en_gb_ht201222.yml' spec/html2rss/configs_dynamic_spec.rb` → exit 0 (13 examples, 0 failures)
- `mise exec -- bundle exec rspec spec/botasaurus_fetch_configs_spec.rb` → exit 0 (4 examples, 0 failures)

## Deferred

- DSW year parameterization — not in this pass
- cnet params redesign — not in this pass
- File rename `rbb24.de/meistgeklickt.yml` → title/url consistency only