### PR TITLE
feat: add directory topics to curated configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 
 # rspec failure tracking
 .rspec_status
+/vendor/bundle/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,11 @@ Primary goal: add or repair configs that are stable, shippable, and easy to veri
 - If the site only becomes reliable on a narrower path, use that narrower path.
 - Omit brittle fields. If dates or descriptions are low quality, leave them out.
 - Set `enhance: false` when enhancement pulls in page chrome, duplicate cards, or unrelated links.
+- Require top-level `directory.topics` (non-empty) using the controlled vocabulary from
+  `Html2rss::Config::Validator::DIRECTORY_TOPICS` (`sports`, `energy`, `tech`, `science`,
+  `news`, `entertainment`, `jobs`, `finance`, `security`, `travel`, `environment`,
+  `consumer`, `civic`, `product`, `research`). Prefer 1–2 primary topics.
+- Prefer setting `channel.language` (`en`/`de`/`es`/`en-GB`/`de-DE`) when the surface language is clear.
 
 ## Surface Selection
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,7 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-# Path gem until html2rss ships directory.topics validation (feat/directory-topics).
-gem 'html2rss', path: '../html2rss'
+gem 'html2rss', github: 'html2rss/html2rss', branch: :master
 
 group :development do
   gem 'nokogiri'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem 'html2rss', '>= 0.25.0'
+# Path gem until html2rss ships directory.topics validation (feat/directory-topics).
+gem 'html2rss', path: '../html2rss'
 
 group :development do
   gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,29 @@
 PATH
+  remote: ../html2rss
+  specs:
+    html2rss (0.25.0)
+      addressable (~> 2.7)
+      brotli
+      dry-validation
+      faraday (> 2.0.1, < 3.0)
+      faraday-follow_redirects
+      faraday-gzip (~> 3)
+      kramdown
+      mcp (~> 1.0)
+      mime-types (> 3.0)
+      nokogiri (>= 1.10, < 2.0)
+      rack (~> 3.0)
+      rackup (~> 2.0)
+      regexp_parser
+      reverse_markdown (~> 3.0)
+      rss
+      sanitize
+      thor
+      tzinfo
+      webrick (~> 1.9)
+      zeitwerk
+
+PATH
   remote: .
   specs:
     html2rss-configs (0.2.0)
@@ -10,34 +35,9 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
-    async (2.44.1)
-      console (~> 1.29)
-      fiber-annotation
-      io-event (~> 1.11)
-    async-http (0.99.0)
-      async (>= 2.35.1)
-      async-pool (~> 0.11)
-      io-endpoint (~> 0.14)
-      io-stream (~> 0.14)
-      protocol-http (~> 0.66)
-      protocol-http1 (~> 0.39)
-      protocol-http2 (~> 0.26)
-      protocol-url (~> 0.2)
-    async-pool (0.11.2)
-      async (>= 2.0)
-    async-websocket (0.30.1)
-      async-http (~> 0.76)
-      protocol-http (~> 0.34)
-      protocol-rack (~> 0.7)
-      protocol-websocket (~> 0.17)
-    base64 (0.3.0)
     bigdecimal (4.1.2)
     brotli (0.8.0)
     concurrent-ruby (1.3.8)
-    console (1.37.0)
-      fiber-annotation
-      fiber-local (~> 1.1)
-      json
     crass (1.0.7)
     diff-lcs (1.6.2)
     dry-configurable (1.4.0)
@@ -86,38 +86,20 @@ GEM
       zlib (~> 3.0)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
-    fiber-annotation (0.2.0)
-    fiber-local (1.1.0)
-      fiber-storage
-    fiber-storage (1.0.1)
-    html2rss (0.25.0)
-      addressable (~> 2.7)
-      brotli
-      dry-validation
-      faraday (> 2.0.1, < 3.0)
-      faraday-follow_redirects
-      faraday-gzip (~> 3)
-      kramdown
-      mime-types (> 3.0)
-      nokogiri (>= 1.10, < 2.0)
-      puppeteer-ruby
-      regexp_parser
-      reverse_markdown (~> 3.0)
-      rss
-      sanitize
-      thor
-      tzinfo
-      zeitwerk
-    io-endpoint (0.17.2)
-    io-event (1.19.5)
-    io-stream (0.14.0)
-      openssl (>= 3.3)
+    hana (1.3.7)
     json (2.21.2)
+    json_schemer (2.5.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
+    mcp (1.2.0)
+      json_schemer (>= 2.4)
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
@@ -130,36 +112,16 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    openssl (4.0.2)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     prism (1.9.0)
-    protocol-hpack (1.5.1)
-    protocol-http (0.70.0)
-    protocol-http1 (0.40.2)
-      protocol-http (~> 0.68)
-    protocol-http2 (0.26.2)
-      protocol-hpack (~> 1.4)
-      protocol-http (~> 0.62)
-    protocol-rack (0.22.1)
-      io-stream (>= 0.10)
-      protocol-http (~> 0.58)
-      rack (>= 1.0)
-    protocol-url (0.18.0)
-    protocol-websocket (0.21.1)
-      protocol-http (~> 0.2)
     public_suffix (7.0.5)
-    puppeteer-ruby (0.53.0)
-      async (>= 2.35.1, < 3.0)
-      async-http (>= 0.60, < 1.0)
-      async-websocket (>= 0.27, < 1.0)
-      base64
-      mime-types (>= 3.0)
-      urlpattern (~> 0.1.1)
     racc (1.8.1)
     rack (3.2.7)
+    rackup (2.3.1)
+      rack (>= 3)
     rainbow (3.1.1)
     regexp_parser (2.12.0)
     reverse_markdown (3.0.2)
@@ -205,14 +167,13 @@ GEM
     sanitize (7.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
+    simpleidn (0.2.3)
     thor (1.5.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
     uri (1.1.1)
-    urlpattern (0.1.1-arm64-darwin)
-    urlpattern (0.1.1-x86_64-darwin)
-    urlpattern (0.1.1-x86_64-linux)
+    webrick (1.9.2)
     zeitwerk (2.8.3)
     zlib (3.2.3)
 
@@ -224,7 +185,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  html2rss (>= 0.25.0)
+  html2rss!
   html2rss-configs!
   nokogiri
   public_suffix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-PATH
-  remote: ../html2rss
+GIT
+  remote: https://github.com/html2rss/html2rss
+  revision: aa974733c6e88a5c934f445516d9752dfa316067
+  branch: master
   specs:
     html2rss (0.25.0)
       addressable (~> 2.7)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ BOTASAURUS_SCRAPER_URL=http://localhost:4010 \
 make test-fetch-botasaurus-configs
 ```
 
-**Adding new configs**: Create the YAML file, run `make validate`, then run the generated tests. No dedicated spec file is needed.
+**Adding new configs**: Create the YAML file with top-level `directory.topics` (controlled vocabulary), run `make validate`, then run the generated tests. No dedicated spec file is needed.
 
 The fetch suite has two lanes:
 

--- a/lib/html2rss/configs/adfc.de/pressemitteilungen.yml
+++ b/lib/html2rss/configs/adfc.de/pressemitteilungen.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
 channel:
   url: https://www.adfc.de/presse/pressemitteilungen/
   time_zone: Europe/Berlin

--- a/lib/html2rss/configs/apnews.com/hub.yml
+++ b/lib/html2rss/configs/apnews.com/hub.yml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - news
 parameters:
   section:
     type: string

--- a/lib/html2rss/configs/apple.com/newsroom.yml
+++ b/lib/html2rss/configs/apple.com/newsroom.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - product
 strategy: botasaurus
 
 channel:

--- a/lib/html2rss/configs/bbc.co.uk/available_episodes.yml
+++ b/lib/html2rss/configs/bbc.co.uk/available_episodes.yml
@@ -1,10 +1,14 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - entertainment
 parameters:
   id:
     type: string
     default: "b006wkfp"
 
 channel:
+  language: en
   url: https://www.bbc.co.uk/programmes/%<id>s/episodes/player
   time_zone: UTC
   ttl: 720

--- a/lib/html2rss/configs/bbc.com/mundo.yml
+++ b/lib/html2rss/configs/bbc.com/mundo.yml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - news
 channel:
   url: https://www.bbc.com/mundo
   language: es

--- a/lib/html2rss/configs/blog.mondediplo.net/feed.yml
+++ b/lib/html2rss/configs/blog.mondediplo.net/feed.yml
@@ -1,10 +1,14 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
 parameters:
   blog:
     type: string
     default: "-Defense-en-ligne-"
 
 channel:
+  language: en
   url: https://blog.mondediplo.net/%<blog>s
   time_zone: Europe/Paris
   title: "blog.mondediplo.net: %<blog>s"

--- a/lib/html2rss/configs/canarianweekly.com/front.yml
+++ b/lib/html2rss/configs/canarianweekly.com/front.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+    - travel
 channel:
   url: https://www.canarianweekly.com/
   time_zone: Europe/London

--- a/lib/html2rss/configs/cinemascore.com/index.yml
+++ b/lib/html2rss/configs/cinemascore.com/index.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - entertainment
 channel:
+  language: en
   url: https://webapp.cinemascore.com/guest/surveys
   ttl: 720
   json: true

--- a/lib/html2rss/configs/cleanenergywire.org/news.yml
+++ b/lib/html2rss/configs/cleanenergywire.org/news.yml
@@ -1,5 +1,10 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - energy
+    - environment
 channel:
+  language: en
   url: https://www.cleanenergywire.org/news
   time_zone: "Europe/Berlin"
   ttl: 360

--- a/lib/html2rss/configs/cnet.com/section_sub.yml
+++ b/lib/html2rss/configs/cnet.com/section_sub.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - tech
+    - news
 parameters:
   section:
     type: string

--- a/lib/html2rss/configs/computerbase.de/meistgelesen.yml
+++ b/lib/html2rss/configs/computerbase.de/meistgelesen.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
 channel:
   title: "computerbase.de: meistgelesen"
   url: https://www.computerbase.de

--- a/lib/html2rss/configs/cutle.fish/index.yml
+++ b/lib/html2rss/configs/cutle.fish/index.yml
@@ -1,6 +1,10 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - tech
 channel:
+  language: en
   url: https://cutle.fish/
   ttl: 360
   time_zone: UTC

--- a/lib/html2rss/configs/deepmind.google/blog.yml
+++ b/lib/html2rss/configs/deepmind.google/blog.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
+    - research
 
 channel:
   url: https://deepmind.google/blog/

--- a/lib/html2rss/configs/deraktionaer.de/meistgelesen.yml
+++ b/lib/html2rss/configs/deraktionaer.de/meistgelesen.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - finance
 channel:
   title: "deraktionaer.de: meistgelesen"
   url: https://www.deraktionaer.de/

--- a/lib/html2rss/configs/developer.apple.com/tutorials_data_documentation_technotes_json.yml
+++ b/lib/html2rss/configs/developer.apple.com/tutorials_data_documentation_technotes_json.yml
@@ -1,6 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - tech
+    - product
 channel:
+  language: en
   json: true
   url: https://developer.apple.com/tutorials/data/documentation/Technotes.json
   ttl: 360

--- a/lib/html2rss/configs/dfs.de/pressemitteilungen.yml
+++ b/lib/html2rss/configs/dfs.de/pressemitteilungen.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
 channel:
   url: https://www.dfs.de/homepage/de/medien/presse/
   time_zone: Europe/Berlin

--- a/lib/html2rss/configs/dsw-info.de/presse.yml
+++ b/lib/html2rss/configs/dsw-info.de/presse.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - consumer
 channel:
   url: https://www.dsw-info.de/presse/pressemitteilungen-2026/
   time_zone: Europe/Berlin

--- a/lib/html2rss/configs/elastic.co/elasticsearch-release-notes.yml
+++ b/lib/html2rss/configs/elastic.co/elasticsearch-release-notes.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - product
 channel:
   url: https://www.elastic.co/docs/release-notes/elasticsearch
   language: en

--- a/lib/html2rss/configs/espn.com/f1.yml
+++ b/lib/html2rss/configs/espn.com/f1.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - sports
 channel:
+  language: en
   url: https://www.espn.com/f1/
   time_zone: UTC
   ttl: 60

--- a/lib/html2rss/configs/fia.com/documents.yml
+++ b/lib/html2rss/configs/fia.com/documents.yml
@@ -1,6 +1,10 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - sports
 channel:
+  language: en
   url: https://www.fia.com/documents/championships/fia-formula-one-world-championship-14/season/season-2026-2072
   ttl: 360
   time_zone: UTC

--- a/lib/html2rss/configs/formula1.com/latest.yml
+++ b/lib/html2rss/configs/formula1.com/latest.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - sports
 channel:
+  language: en
   url: https://www.formula1.com/en/latest
   time_zone: UTC
   ttl: 120

--- a/lib/html2rss/configs/github.com/releases.yml
+++ b/lib/html2rss/configs/github.com/releases.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - product
 parameters:
   username:
     type: string
@@ -8,6 +12,7 @@ parameters:
     default: "nuxt"
 
 channel:
+  language: en
   url: https://github.com/%<username>s/%<repository>s/releases
   time_zone: UTC
   ttl: 720

--- a/lib/html2rss/configs/go.dev/release-history.yml
+++ b/lib/html2rss/configs/go.dev/release-history.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - product
 channel:
   url: https://go.dev/doc/devel/release
   language: en

--- a/lib/html2rss/configs/grafana.com/whatsnew.yml
+++ b/lib/html2rss/configs/grafana.com/whatsnew.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - product
 channel:
   url: https://grafana.com/docs/grafana/latest/whatsnew/
   language: en

--- a/lib/html2rss/configs/iaapa.org/news.yml
+++ b/lib/html2rss/configs/iaapa.org/news.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - entertainment
 channel:
+  language: en
   url: https://iaapa.org/news-funworld
   time_zone: UTC
   ttl: 720

--- a/lib/html2rss/configs/imdb.com/ratings.yml
+++ b/lib/html2rss/configs/imdb.com/ratings.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - entertainment
 strategy: botasaurus
 
 parameters:
@@ -7,6 +10,7 @@ parameters:
     default: "ur7019649"
 
 channel:
+  language: en
   url: https://www.imdb.com/user/%<user_id>s/ratings
   time_zone: UTC
   ttl: 1440

--- a/lib/html2rss/configs/ingenieur.de/karriere_arbeitsleben_heiko_mell.yml
+++ b/lib/html2rss/configs/ingenieur.de/karriere_arbeitsleben_heiko_mell.yml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - jobs
 channel:
   url: https://www.ingenieur.de/karriere/arbeitsleben/heiko-mell/
   language: de-DE

--- a/lib/html2rss/configs/kinocheck.de/filmstarts.yml
+++ b/lib/html2rss/configs/kinocheck.de/filmstarts.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - entertainment
 channel:
   url: https://kinocheck.de/filmstarts
   time_zone: Europe/Berlin

--- a/lib/html2rss/configs/microsoft.com/azure-products.yml
+++ b/lib/html2rss/configs/microsoft.com/azure-products.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - product
 channel:
   url: https://azure.microsoft.com/en-us/products
   language: en

--- a/lib/html2rss/configs/mozilla.org/security-advisories.yml
+++ b/lib/html2rss/configs/mozilla.org/security-advisories.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - security
+    - tech
 channel:
   url: https://www.mozilla.org/en-US/security/advisories/
   language: en

--- a/lib/html2rss/configs/newyorker.com/magazine.yml
+++ b/lib/html2rss/configs/newyorker.com/magazine.yml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - news
 channel:
   url: https://www.newyorker.com/magazine
   language: en

--- a/lib/html2rss/configs/nomanssky.com/news.yml
+++ b/lib/html2rss/configs/nomanssky.com/news.yml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - entertainment
 channel:
   url: https://www.nomanssky.com/news/
   language: en-GB

--- a/lib/html2rss/configs/notion.com/blog.yml
+++ b/lib/html2rss/configs/notion.com/blog.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - product
 
 channel:
   url: https://www.notion.com/blog

--- a/lib/html2rss/configs/pankow.lebensmittel-kontrollergebnisse.de/search.yml
+++ b/lib/html2rss/configs/pankow.lebensmittel-kontrollergebnisse.de/search.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - consumer
+    - civic
 channel:
   url: https://pankow.lebensmittel-kontrollergebnisse.de/Search
   language: de

--- a/lib/html2rss/configs/phys.org/weekly.yml
+++ b/lib/html2rss/configs/phys.org/weekly.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
 channel:
+  language: en
   url: https://phys.org/weekly-news/
   time_zone: Europe/London
   ttl: 1440

--- a/lib/html2rss/configs/rbb24.de/meistgeklickt.yml
+++ b/lib/html2rss/configs/rbb24.de/meistgeklickt.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
 channel:
   title: "rbb24.de: Das Beste"
   url: https://www.rbb24.de/das-beste/

--- a/lib/html2rss/configs/robinwood.de/aktuelles.yml
+++ b/lib/html2rss/configs/robinwood.de/aktuelles.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - environment
 channel:
   url: https://www.robinwood.de/was-gibt-es-neues
   time_zone: Europe/Berlin

--- a/lib/html2rss/configs/s3.amazonaws.com/popular_movies.yml
+++ b/lib/html2rss/configs/s3.amazonaws.com/popular_movies.yml
@@ -1,7 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - entertainment
 # This generates a RSS of the daily updated
 # https://github.com/sjlu/popular-movies
 channel:
+  language: en
   url: https://s3.amazonaws.com/popular-movies/movies.json
   time_zone: UTC
   ttl: 1440

--- a/lib/html2rss/configs/sebastianvettel.de/news.yml
+++ b/lib/html2rss/configs/sebastianvettel.de/news.yml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - sports
 channel:
   url: https://sebastianvettel.de/
   language: de-DE

--- a/lib/html2rss/configs/shopify.com/blog.yml
+++ b/lib/html2rss/configs/shopify.com/blog.yml
@@ -1,6 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - product
 
 channel:
+  language: en
   url: https://www.shopify.com/blog/latest
   time_zone: UTC
   ttl: 360

--- a/lib/html2rss/configs/softwareleadweekly.com/issues.yml
+++ b/lib/html2rss/configs/softwareleadweekly.com/issues.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
 channel:
+  language: en
   url: https://softwareleadweekly.com/issues
   time_zone: UTC
   ttl: 720

--- a/lib/html2rss/configs/solarthermalworld.org/news.yml
+++ b/lib/html2rss/configs/solarthermalworld.org/news.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - energy
 channel:
+  language: en
   url: https://solarthermalworld.org/news
   time_zone: UTC
   ttl: 180

--- a/lib/html2rss/configs/spektrum.de/meistgelesen.yml
+++ b/lib/html2rss/configs/spektrum.de/meistgelesen.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
 channel:
   title: "spektrum.de: meistgelesen"
   url: https://www.spektrum.de/

--- a/lib/html2rss/configs/spiegel.de/impressum_autor.yml
+++ b/lib/html2rss/configs/spiegel.de/impressum_autor.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
 parameters:
   id:
     type: string

--- a/lib/html2rss/configs/spotify.com/newsroom.yml
+++ b/lib/html2rss/configs/spotify.com/newsroom.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - entertainment
 
 channel:
   url: https://newsroom.spotify.com/

--- a/lib/html2rss/configs/stackoverflow.com/hot_network_questions.yml
+++ b/lib/html2rss/configs/stackoverflow.com/hot_network_questions.yml
@@ -1,7 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
 strategy: botasaurus
 
 channel:
+  language: en
   title: "stackoverflow.com: Hot Network Questions"
   url: https://stackoverflow.com/questions
   time_zone: America/New_York

--- a/lib/html2rss/configs/steuerzahler.de/news.yml
+++ b/lib/html2rss/configs/steuerzahler.de/news.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
 channel:
   url: https://www.steuerzahler.de/news/
   time_zone: Europe/Berlin

--- a/lib/html2rss/configs/stripes.com/index.yml
+++ b/lib/html2rss/configs/stripes.com/index.yml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - news
 channel:
   url: https://www.stripes.com/
   language: en

--- a/lib/html2rss/configs/support.apple.com/en_gb_ht201222.yml
+++ b/lib/html2rss/configs/support.apple.com/en_gb_ht201222.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - tech
+    - security
 strategy: botasaurus
 
 channel:

--- a/lib/html2rss/configs/support.apple.com/exchange_repair.yml
+++ b/lib/html2rss/configs/support.apple.com/exchange_repair.yml
@@ -1,5 +1,10 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - security
 channel:
+  language: en
   url: https://support.apple.com/service-programs
   time_zone: America/Los_Angeles
   ttl: 720

--- a/lib/html2rss/configs/teneriffa-news.com/news.yml
+++ b/lib/html2rss/configs/teneriffa-news.com/news.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+    - travel
 channel:
   url: https://www.teneriffa-news.com/news
   time_zone: "Europe/Lisbon"

--- a/lib/html2rss/configs/test.de/archiv.yml
+++ b/lib/html2rss/configs/test.de/archiv.yml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - consumer
 channel:
   url: https://www.test.de/archiv/
   language: de

--- a/lib/html2rss/configs/theguardian.com/international_mostpopular.yml
+++ b/lib/html2rss/configs/theguardian.com/international_mostpopular.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
 channel:
+  language: en
   title: "theguardian.com: International most popular"
   url: https://www.theguardian.com/international
   time_zone: Europe/London

--- a/lib/html2rss/configs/thoughtworks.com/insights.yml
+++ b/lib/html2rss/configs/thoughtworks.com/insights.yml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - research
 strategy: botasaurus
 
 channel:

--- a/lib/html2rss/configs/tourismusnetzwerk-brandenburg.de/aktuelle_nachrichten.yml
+++ b/lib/html2rss/configs/tourismusnetzwerk-brandenburg.de/aktuelle_nachrichten.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - travel
 channel:
   url: https://tourismusnetzwerk-brandenburg.de/
   time_zone: Europe/Berlin

--- a/lib/html2rss/configs/webentwickler-jobs.de/in.yml
+++ b/lib/html2rss/configs/webentwickler-jobs.de/in.yml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
 ---
+directory:
+  topics:
+    - jobs
 parameters:
   region:
     type: string

--- a/spec/support/shared_examples/config.yml_spec.rb
+++ b/spec/support/shared_examples/config.yml_spec.rb
@@ -49,6 +49,20 @@ RSpec.shared_examples 'config.yml' do |file_name, params|
       expect(yaml).to have_key 'selectors'
     end
 
+    context 'with directory present' do
+      it 'has non-empty topics from the controlled vocabulary', :aggregate_failures do
+        expect(yaml).to have_key('directory')
+        topics = yaml.dig('directory', 'topics')
+        expect(topics).to be_an(Array)
+        expect(topics).not_to be_empty
+
+        vocabulary = Html2rss::Config::Validator::DIRECTORY_TOPICS
+        topics.each do |topic|
+          expect(vocabulary).to include(topic), "unknown topic `#{topic}` (allowed: #{vocabulary.join(', ')})"
+        end
+      end
+    end
+
     context 'with channel present' do
       it 'has channel required attributes', :aggregate_failures do
         %w[url ttl time_zone].each do |required_attribute|

--- a/spec/support/shared_examples/config.yml_spec.rb
+++ b/spec/support/shared_examples/config.yml_spec.rb
@@ -50,7 +50,7 @@ RSpec.shared_examples 'config.yml' do |file_name, params|
     end
 
     context 'with directory present' do
-      it 'has non-empty topics from the controlled vocabulary', :aggregate_failures do
+      it 'has non-empty topics from the controlled vocabulary', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
         expect(yaml).to have_key('directory')
         topics = yaml.dig('directory', 'topics')
         expect(topics).to be_an(Array)


### PR DESCRIPTION
## What changed

- Tag curated YAML feeds under `lib/html2rss/configs/` with catalog `directory.topics` from the core vocabulary.
- Fill obvious `channel.language` gaps where the surface language is clear.
- Guard the non-empty topics requirement in `spec/support/shared_examples/config.yml_spec.rb`.
- Point `Gemfile` at `html2rss` `feat/directory-topics` (github branch) so CI can validate against the unreleased schema.

## Why

Catalog metadata for the docs feed directory filters ([html2rss/html2rss.github.io#135](https://github.com/html2rss/html2rss.github.io/issues/135)). Depends on the core schema work in https://github.com/html2rss/html2rss/pull/458.

## Risk

- **Blocked on** https://github.com/html2rss/html2rss/pull/458 — merge core first; this Gemfile pin tracks that branch until a release.
- Large surface: every curated config gains topics; wrong topic picks are low-severity catalog noise, not fetch breakage.

## Review map

1. `Gemfile` / `Gemfile.lock` — github branch pin for html2rss (CI dependency).
2. `spec/support/shared_examples/config.yml_spec.rb` — enforcement contract.
3. Sample a few `lib/html2rss/configs/**/*.yml` for topic/language choices; rest is mechanical.

## Validation

- not run in this open step beyond `bundle lock` after the Gemfile pin change

## Depends on

- https://github.com/html2rss/html2rss/pull/458 (**must merge first**)

## Merge order

**core → configs → docs**. Do not merge this until the core PR is in.