### PR TITLE
feat(configs): add global primary and industry feed configs with topics

### DIFF
--- a/.agents/skills/html2rss-config/SKILL.md
+++ b/.agents/skills/html2rss-config/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: html2rss-config
+description: >-
+  Create or repair curated html2rss YAML feed configs in this repo (lib/html2rss/configs/),
+  including directory.topics, selectors, Faraday vs Botasaurus triage, and the AGENTS.md
+  quality gate. Use when adding a new feed config, fixing a broken/zero-item config,
+  tightening selectors, or diagnosing fetch failures for a curated config. Do not use for
+  html2rss gem core, html2rss-web, docs-only work, or bulk coverage-expansion campaigns.
+---
+
+# html2rss-config
+
+Thin workflow skill for **one config at a time**. Quality-gate SSOT: repo root [`AGENTS.md`](../../../AGENTS.md). Do not duplicate that gate here.
+
+## Modes
+
+| Mode     | When                                                     | Reference                                  |
+| -------- | -------------------------------------------------------- | ------------------------------------------ |
+| `new`    | Add a YAML under `lib/html2rss/configs/<domain>/`        | [reference/new.md](reference/new.md)       |
+| `repair` | Fix existing config (zero items, fetch fail, noisy feed) | [reference/repair.md](reference/repair.md) |
+
+Pick mode from the user ask. Grow later with more modes/references; keep this file short.
+
+## Before any write
+
+1. Read [`AGENTS.md`](../../../AGENTS.md) (surface selection, selectors, drop rules).
+2. Confirm canonical URL (`curl -I -L`); prefer **registrable-domain** folder.
+3. Assign `directory.topics` (1–2) — see [reference/topics.md](reference/topics.md).
+4. If a solid first-party RSS already covers the surface and curated value is low → **drop/defer** with evidence (AGENTS.md).
+
+## Tool order
+
+1. **user-html2rss MCP** — `capture_config` / `scrape_url` / `inspect_url` / `validate_config` when discovery works.
+2. Else **core CLI** from sibling `../html2rss` — `html2rss validate|feed` (or `bundle exec exe/html2rss …`).
+3. **Botasaurus** when Faraday returns zero items: `BOTASAURUS_SCRAPER_URL=http://localhost:4010`.
+4. **Chrome MCP** only if Faraday + Botasaurus fail or the item boundary is unclear. Report Chrome outage in handoff if unavailable.
+
+## Fast path (quick)
+
+Soft budget: one tight loop per site (~3–4 minutes of wall effort). Faraday → Botasaurus → Chrome. If still zero/noisy → **stop**, report drop/defer with evidence, unless the user says keep going.
+
+Minimal selectors first: `items`, `title`, `url`. Omit brittle optional fields. Set `enhance: false` when chrome leaks in.
+
+## Done checklist
+
+From AGENTS.md Quality Gate, in order:
+
+1. `html2rss validate /abs/path/to/config.yml`
+2. `html2rss feed /abs/path/to/config.yml` — clean items, no nav junk
+3. `make validate` (this repo)
+4. `make test` (non-fetch)
+5. Focused fetch:
+   - Faraday: `bundle exec rspec --tag fetch --example 'domain/file.yml' spec/html2rss/configs_dynamic_spec.rb`
+   - Botasaurus: same with `BOTASAURUS_SCRAPER_URL=http://localhost:4010`
+6. If `strategy: botasaurus` (or fetch only works via Botasaurus): add path to [`spec/support/botasaurus_fetch_configs.rb`](../../../spec/support/botasaurus_fetch_configs.rb) — **required**.
+
+## Handoff
+
+Report: mode, files changed, accepted vs dropped/deferred + why, topics, Faraday vs Botasaurus, Chrome MCP availability, commands + exit honesty, residual risks (selector drift, localization, Botasaurus dependence).
+
+Do not push or open a PR unless the user asks. Commits only when the user asks (global commit rules).

--- a/.agents/skills/html2rss-config/SKILL.md
+++ b/.agents/skills/html2rss-config/SKILL.md
@@ -26,7 +26,7 @@ Pick mode from the user ask. Grow later with more modes/references; keep this fi
 1. Read [`AGENTS.md`](../../../AGENTS.md) (surface selection, selectors, drop rules).
 2. Confirm canonical URL (`curl -I -L`); prefer **registrable-domain** folder.
 3. Assign `directory.topics` (1–2) — see [reference/topics.md](reference/topics.md).
-4. If a solid first-party RSS already covers the surface and curated value is low → **drop/defer** with evidence (AGENTS.md).
+4. If a solid first-party RSS already covers the surface and curated value is low → **drop/defer** with evidence (AGENTS.md). Use `scripts/probe_rss` for a quick check.
 
 ## Tool order
 
@@ -41,18 +41,36 @@ Soft budget: one tight loop per site (~3–4 minutes of wall effort). Faraday �
 
 Minimal selectors first: `items`, `title`, `url`. Omit brittle optional fields. Set `enhance: false` when chrome leaks in.
 
+## Scripts
+
+Run from repo root. Prefer these over ad‑hoc CLI glue:
+
+| Script                                                       | Purpose                                                                     |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| [`scripts/probe_rss`](scripts/probe_rss)                     | First-party RSS probe. Exit `0` = none; `3` = found (consider drop).        |
+| [`scripts/check_config`](scripts/check_config)               | `validate` + `feed` (fail on 0 items); optional `--fetch` / `--botasaurus`. |
+| [`scripts/register_botasaurus`](scripts/register_botasaurus) | Idempotent sorted add to `spec/support/botasaurus_fetch_configs.rb`.        |
+
+Examples:
+
+```bash
+.agents/skills/html2rss-config/scripts/probe_rss 'https://example.com/news/'
+.agents/skills/html2rss-config/scripts/check_config domain/file.yml
+.agents/skills/html2rss-config/scripts/check_config domain/file.yml --fetch --botasaurus
+.agents/skills/html2rss-config/scripts/register_botasaurus domain/file.yml
+```
+
 ## Done checklist
 
 From AGENTS.md Quality Gate, in order:
 
-1. `html2rss validate /abs/path/to/config.yml`
-2. `html2rss feed /abs/path/to/config.yml` — clean items, no nav junk
-3. `make validate` (this repo)
-4. `make test` (non-fetch)
-5. Focused fetch:
+1. Prefer `scripts/check_config <path>` (or raw `html2rss validate` + `feed`)
+2. `make validate` (this repo) when touching shared support files or multiple configs
+3. `make test` (non-fetch)
+4. Focused fetch via `scripts/check_config … --fetch` or:
    - Faraday: `bundle exec rspec --tag fetch --example 'domain/file.yml' spec/html2rss/configs_dynamic_spec.rb`
    - Botasaurus: same with `BOTASAURUS_SCRAPER_URL=http://localhost:4010`
-6. If `strategy: botasaurus` (or fetch only works via Botasaurus): add path to [`spec/support/botasaurus_fetch_configs.rb`](../../../spec/support/botasaurus_fetch_configs.rb) — **required**.
+5. If `strategy: botasaurus` (or fetch only works via Botasaurus): `scripts/register_botasaurus domain/file.yml` — **required**.
 
 ## Handoff
 

--- a/.agents/skills/html2rss-config/SKILL.md
+++ b/.agents/skills/html2rss-config/SKILL.md
@@ -31,9 +31,11 @@ Pick mode from the user ask. Grow later with more modes/references; keep this fi
 ## Tool order
 
 1. **user-html2rss MCP** — `capture_config` / `scrape_url` / `inspect_url` / `validate_config` when discovery works.
-2. Else **core CLI** from sibling `../html2rss` — `html2rss validate|feed` (or `bundle exec exe/html2rss …`).
+2. Else **core CLI** from PATH or sibling `../html2rss` — `scripts/check_config` resolves this (or raw `html2rss` / `bundle exec exe/html2rss`).
 3. **Botasaurus** when Faraday returns zero items: `BOTASAURUS_SCRAPER_URL=http://localhost:4010`.
 4. **Chrome MCP** only if Faraday + Botasaurus fail or the item boundary is unclear. Report Chrome outage in handoff if unavailable.
+
+If MCP discovery fails or the MCP process lacks `BOTASAURUS_SCRAPER_URL`, **skip MCP** and go straight to the CLI — do not burn the timebox retrying discovery.
 
 ## Fast path (quick)
 
@@ -47,8 +49,8 @@ Run from repo root. Prefer these over ad‑hoc CLI glue:
 
 | Script                                                       | Purpose                                                                     |
 | ------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| [`scripts/probe_rss`](scripts/probe_rss)                     | First-party RSS probe. Exit `0` = none; `3` = found (consider drop).        |
-| [`scripts/check_config`](scripts/check_config)               | `validate` + `feed` (fail on 0 items); optional `--fetch` / `--botasaurus`. |
+| [`scripts/probe_rss`](scripts/probe_rss)                     | First-party RSS probe (HTML `rel=alternate` then path guesses). Exit `0` = none; `3` = found (consider drop). Under `set -e`, check `$?` — do not treat `3` as failure. |
+| [`scripts/check_config`](scripts/check_config)               | `validate` + `feed` (fail on 0 items); optional `--fetch` / `--botasaurus`. Resolves CLI via PATH or sibling `../html2rss`. |
 | [`scripts/register_botasaurus`](scripts/register_botasaurus) | Idempotent sorted add to `spec/support/botasaurus_fetch_configs.rb`.        |
 
 Examples:

--- a/.agents/skills/html2rss-config/reference/new.md
+++ b/.agents/skills/html2rss-config/reference/new.md
@@ -4,11 +4,11 @@ Add one curated config. SSOT details: [AGENTS.md](../../../../AGENTS.md).
 
 ## Steps
 
-1. Confirm no useful first-party RSS for this surface (else drop/defer).
+1. Confirm no useful first-party RSS for this surface (else drop/defer). Use `scripts/probe_rss`.
 2. Pick the cleanest list URL (newsroom / archive / category — not marketing homepage).
 3. Capture items via skill tool order (MCP → CLI → Botasaurus → Chrome).
 4. Write YAML under `lib/html2rss/configs/<registrable-domain>/<name>.yml`.
-5. Run AGENTS.md Quality Gate; register Botasaurus path if needed.
+5. Run `scripts/check_config …` (and `--fetch` / `--botasaurus` as needed); `scripts/register_botasaurus` if Botasaurus-backed.
 6. Handoff per skill.
 
 ## YAML skeleton

--- a/.agents/skills/html2rss-config/reference/new.md
+++ b/.agents/skills/html2rss-config/reference/new.md
@@ -4,7 +4,7 @@ Add one curated config. SSOT details: [AGENTS.md](../../../../AGENTS.md).
 
 ## Steps
 
-1. Confirm no useful first-party RSS for this surface (else drop/defer). Use `scripts/probe_rss`.
+1. Confirm no useful first-party RSS for this surface (else drop/defer). Use `scripts/probe_rss` (HTML `rel=alternate` first, then path guesses). Exit `3` = feed found.
 2. Pick the cleanest list URL (newsroom / archive / category — not marketing homepage).
 3. Capture items via skill tool order (MCP → CLI → Botasaurus → Chrome).
 4. Write YAML under `lib/html2rss/configs/<registrable-domain>/<name>.yml`.
@@ -45,3 +45,10 @@ Notes:
 ## Ship bar
 
 Live `feed` shows repeated real articles, no nav/footer leakage, absolute URLs. Then repo `make validate` + `make test` + focused fetch.
+
+Footnotes from campaign experience:
+
+- **Folder name:** registrable domain only — avoid `www.` folders unless the host is uniquely `www`.
+- **Archive size:** if the list HTML embeds a full multi-year archive (hundreds–thousands of items), prefer a `/latest` or paginated surface; otherwise note the blast radius in handoff.
+- **Paywall:** titles that work while bodies are gated are shippable; mention premium/paywall risk in handoff.
+- **MCP:** if `user-html2rss` discovery is errored or missing `BOTASAURUS_SCRAPER_URL`, skip MCP and use the CLI path immediately.

--- a/.agents/skills/html2rss-config/reference/new.md
+++ b/.agents/skills/html2rss-config/reference/new.md
@@ -1,0 +1,47 @@
+# Mode: new
+
+Add one curated config. SSOT details: [AGENTS.md](../../../../AGENTS.md).
+
+## Steps
+
+1. Confirm no useful first-party RSS for this surface (else drop/defer).
+2. Pick the cleanest list URL (newsroom / archive / category — not marketing homepage).
+3. Capture items via skill tool order (MCP → CLI → Botasaurus → Chrome).
+4. Write YAML under `lib/html2rss/configs/<registrable-domain>/<name>.yml`.
+5. Run AGENTS.md Quality Gate; register Botasaurus path if needed.
+6. Handoff per skill.
+
+## YAML skeleton
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+channel:
+  url: https://example.com/news/
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: "ARTICLE_CARD_OR_ANCHOR"
+    enhance: false
+  title:
+    selector: "TITLE_WITHIN_ITEM"
+  url:
+    selector: "a"
+    extractor: href
+```
+
+Notes:
+
+- Always include `directory.topics` (1–2) — see [topics.md](topics.md).
+- Set `channel.language` when clear (`en` / `de` / `es` / …).
+- Add `strategy: botasaurus` + request wait selectors only when Faraday cannot produce items.
+- Parameterized URLs need a `parameters:` block with `type: string` and `default`.
+- Prefer item-local selectors; anchor on article URL path fragments when possible.
+
+## Ship bar
+
+Live `feed` shows repeated real articles, no nav/footer leakage, absolute URLs. Then repo `make validate` + `make test` + focused fetch.

--- a/.agents/skills/html2rss-config/reference/repair.md
+++ b/.agents/skills/html2rss-config/reference/repair.md
@@ -10,7 +10,7 @@ Fix one existing config. SSOT: [AGENTS.md](../../../../AGENTS.md). Runtime Debug
    - Retry with Botasaurus (`BOTASAURUS_SCRAPER_URL=http://localhost:4010` or `check_config … --botasaurus`).
    - If Botasaurus works → keep config narrow; set `strategy: botasaurus`; run `scripts/register_botasaurus`.
 4. If both request strategies fail or items are wrong → Chrome MCP snapshot; confirm item boundary / final URL after redirects.
-5. Compare core `feed` vs configs-repo focused fetch when they disagree (request-strategy mismatch, not “selectors OK”).
+5. Compare core `feed` vs configs-repo focused fetch when they disagree (request-strategy mismatch, not “selectors OK”). Agency/CDN sites often treat the gem UA differently than a browser — expect intermittent 403/504 in the fetch lane even when CLI `feed` looked fine; prefer Botasaurus or drop.
 
 ## Fix order
 

--- a/.agents/skills/html2rss-config/reference/repair.md
+++ b/.agents/skills/html2rss-config/reference/repair.md
@@ -1,0 +1,29 @@
+# Mode: repair
+
+Fix one existing config. SSOT: [AGENTS.md](../../../../AGENTS.md). Runtime Debugging section there is authoritative.
+
+## Diagnose (cheapest first)
+
+1. Read the YAML; note `channel.url`, selectors, `strategy`.
+2. `html2rss validate` then `html2rss feed` on the absolute path (core CLI).
+3. If zero items with Faraday:
+   - Retry with Botasaurus (`BOTASAURUS_SCRAPER_URL=http://localhost:4010`).
+   - If Botasaurus works → keep config narrow; set `strategy: botasaurus`; register in `spec/support/botasaurus_fetch_configs.rb`.
+4. If both request strategies fail or items are wrong → Chrome MCP snapshot; confirm item boundary / final URL after redirects.
+5. Compare core `feed` vs configs-repo focused fetch when they disagree (request-strategy mismatch, not “selectors OK”).
+
+## Fix order
+
+1. Wrong/canonical URL or locale redirect → fix `channel.url`.
+2. Noisy enhancement → `enhance: false` on items (or channel).
+3. Over-broad `items` → tighten to repeated article card / content link.
+4. Drop weak optional fields (`description`, `published_at`, `categories`) before adding selector complexity.
+5. Narrower path if the flagship page is unsalvageable.
+
+## Stop / drop
+
+After one tight loop (~3–4 minutes) with evidence: report **deferred** or recommend **drop** if still noisy, blocked (401/403/timeout), or first-party RSS makes the curated config low value — unless the user says keep going.
+
+## Done
+
+Same Quality Gate as [SKILL.md](../SKILL.md). Focused fetch must match the strategy you ship. Handoff: root cause, what changed, residual drift risk.

--- a/.agents/skills/html2rss-config/reference/repair.md
+++ b/.agents/skills/html2rss-config/reference/repair.md
@@ -5,10 +5,10 @@ Fix one existing config. SSOT: [AGENTS.md](../../../../AGENTS.md). Runtime Debug
 ## Diagnose (cheapest first)
 
 1. Read the YAML; note `channel.url`, selectors, `strategy`.
-2. `html2rss validate` then `html2rss feed` on the absolute path (core CLI).
+2. `scripts/check_config <path>` (or `html2rss validate` then `html2rss feed`).
 3. If zero items with Faraday:
-   - Retry with Botasaurus (`BOTASAURUS_SCRAPER_URL=http://localhost:4010`).
-   - If Botasaurus works → keep config narrow; set `strategy: botasaurus`; register in `spec/support/botasaurus_fetch_configs.rb`.
+   - Retry with Botasaurus (`BOTASAURUS_SCRAPER_URL=http://localhost:4010` or `check_config … --botasaurus`).
+   - If Botasaurus works → keep config narrow; set `strategy: botasaurus`; run `scripts/register_botasaurus`.
 4. If both request strategies fail or items are wrong → Chrome MCP snapshot; confirm item boundary / final URL after redirects.
 5. Compare core `feed` vs configs-repo focused fetch when they disagree (request-strategy mismatch, not “selectors OK”).
 

--- a/.agents/skills/html2rss-config/reference/topics.md
+++ b/.agents/skills/html2rss-config/reference/topics.md
@@ -18,9 +18,17 @@ Prefer **1–2** primary topics. Do not invent strings.
 | Gov / IGO / regulator press        | `civic`                                   |
 | Think tank analysis                | `civic` + `research`                      |
 | Science institute / lab            | `science` + `research`                    |
+| Space agency                       | `science` + `research`                    |
 | General newsroom                   | `news`                                    |
+| Investigative / OSINT newsroom     | `news` + `civic`                          |
 | Energy / climate agency            | `energy` + `environment`                  |
 | Markets / central bank / IMF-class | `finance` + `civic`                       |
+| Patents / IP office                | `civic` + `tech`                          |
+| Courts / legal press               | `civic`                                   |
+| Aviation / shipping regulator      | `civic`                                   |
+| Telecom / spectrum regulator       | `civic` + `tech`                          |
+| Semiconductors / hardware vendor   | `tech` + `product`                        |
+| Food / agriculture agency          | `environment` + `civic`                   |
 | Jobs board                         | `jobs`                                    |
 | Consumer tests / recalls           | `consumer` (+ `civic`)                    |
 | Travel / local visitor news        | `travel` (+ `news`)                       |

--- a/.agents/skills/html2rss-config/reference/topics.md
+++ b/.agents/skills/html2rss-config/reference/topics.md
@@ -1,0 +1,30 @@
+# directory.topics
+
+Required on every config. Vocabulary SSOT: `Html2rss::Config::Validator::DIRECTORY_TOPICS` (also listed in [AGENTS.md](../../../../AGENTS.md)).
+
+Prefer **1–2** primary topics. Do not invent strings.
+
+## Vocabulary
+
+`sports`, `energy`, `tech`, `science`, `news`, `entertainment`, `jobs`, `finance`, `security`, `travel`, `environment`, `consumer`, `civic`, `product`, `research`
+
+## Quick mapping
+
+| Surface                            | Typical topics                            |
+| ---------------------------------- | ----------------------------------------- |
+| AI / eng blog, OSS release notes   | `tech` + `research` or `tech` + `product` |
+| Company product newsroom           | `tech` + `product`                        |
+| Security advisories / cyber agency | `security` (+ `tech` or `civic`)          |
+| Gov / IGO / regulator press        | `civic`                                   |
+| Think tank analysis                | `civic` + `research`                      |
+| Science institute / lab            | `science` + `research`                    |
+| General newsroom                   | `news`                                    |
+| Energy / climate agency            | `energy` + `environment`                  |
+| Markets / central bank / IMF-class | `finance` + `civic`                       |
+| Jobs board                         | `jobs`                                    |
+| Consumer tests / recalls           | `consumer` (+ `civic`)                    |
+| Travel / local visitor news        | `travel` (+ `news`)                       |
+| Sports                             | `sports`                                  |
+| Film / games / music               | `entertainment`                           |
+
+Ambiguous hybrid: pick audience intent, not every plausible tag.

--- a/.agents/skills/html2rss-config/scripts/check_config
+++ b/.agents/skills/html2rss-config/scripts/check_config
@@ -37,30 +37,28 @@ def feed_example_name(config_path, root)
   config_path.relative_path_from(root / 'lib/html2rss/configs').to_s
 end
 
+def invoke_entry(entry, sibling)
+  return nil unless entry.file?
+  return ['bundle', 'exec', entry.to_s] if (sibling / 'Gemfile').file?
+
+  [entry.to_s]
+end
+
+def sibling_html2rss_invocation(root)
+  sibling = root.parent / 'html2rss'
+  invoke_entry(sibling / 'exe' / 'html2rss', sibling) ||
+    invoke_entry(sibling / 'bin' / 'html2rss', sibling) ||
+    abort(<<~MSG)
+      html2rss CLI not found on PATH and no sibling checkout at #{sibling}.
+      Install the CLI or clone html2rss next to html2rss-configs (AGENTS.md).
+    MSG
+end
+
 # Prefer PATH `html2rss`, then sibling ../html2rss (exe via bundle, then bin).
 def resolve_html2rss_invocation(root)
-  path_bin = `command -v html2rss 2>/dev/null`.strip
-  return ['html2rss'] unless path_bin.empty?
+  return ['html2rss'] unless `command -v html2rss 2>/dev/null`.strip.empty?
 
-  sibling = root.parent / 'html2rss'
-  exe = sibling / 'exe' / 'html2rss'
-  if exe.file?
-    return ['bundle', 'exec', exe.to_s] if (sibling / 'Gemfile').file?
-
-    return [exe.to_s]
-  end
-
-  bin = sibling / 'bin' / 'html2rss'
-  if bin.file?
-    return ['bundle', 'exec', bin.to_s] if (sibling / 'Gemfile').file?
-
-    return [bin.to_s]
-  end
-
-  abort(<<~MSG)
-    html2rss CLI not found on PATH and no sibling checkout at #{sibling}.
-    Install the CLI or clone html2rss next to html2rss-configs (AGENTS.md).
-  MSG
+  sibling_html2rss_invocation(root)
 end
 
 def run!(*cmd, env: {}, quiet: false, chdir: nil)

--- a/.agents/skills/html2rss-config/scripts/check_config
+++ b/.agents/skills/html2rss-config/scripts/check_config
@@ -1,0 +1,81 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Validate + feed (+ optional focused fetch) for one curated config.
+# Usage (from repo root):
+#   .agents/skills/html2rss-config/scripts/check_config lib/html2rss/configs/domain/file.yml
+#   .agents/skills/html2rss-config/scripts/check_config domain/file.yml --fetch
+#   .agents/skills/html2rss-config/scripts/check_config domain/file.yml --fetch --botasaurus
+
+require 'open3'
+require 'pathname'
+
+def usage!
+  warn <<~USAGE
+    Usage: check_config <config.yml|domain/file.yml> [--fetch] [--botasaurus]
+  USAGE
+  exit 1
+end
+
+def repo_root
+  Pathname.new(__dir__).ascend.find { |p| (p / 'lib/html2rss/configs').directory? } ||
+    abort('Could not find html2rss-configs repo root')
+end
+
+def resolve_config(arg, root)
+  path = Pathname.new(arg)
+  candidates = []
+  candidates << path if path.absolute?
+  candidates << (root / path)
+  candidates << (root / 'lib/html2rss/configs' / path)
+  found = candidates.find(&:file?)
+  abort("Config not found: #{arg}") unless found
+  found.expand_path
+end
+
+def feed_example_name(config_path, root)
+  config_path.relative_path_from(root / 'lib/html2rss/configs').to_s
+end
+
+def run!(*cmd, env: {}, quiet: false)
+  puts "+ #{cmd.join(' ')}"
+  out, status = Open3.capture2e(env, *cmd)
+  puts out unless quiet
+  abort("Command failed (#{status.exitstatus}): #{cmd.join(' ')}\n#{out}") unless status.success?
+  out
+end
+
+def count_items(rss)
+  rss.scan(/<item[\s>]/i).size
+end
+
+usage! if ARGV.empty? || ARGV.include?('-h') || ARGV.include?('--help')
+
+fetch = ARGV.delete('--fetch')
+botasaurus = ARGV.delete('--botasaurus')
+usage! unless ARGV.size == 1
+
+root = repo_root
+config = resolve_config(ARGV.fetch(0), root)
+example = feed_example_name(config, root)
+env = {}
+env['BOTASAURUS_SCRAPER_URL'] = ENV.fetch('BOTASAURUS_SCRAPER_URL', 'http://localhost:4010') if botasaurus
+
+Dir.chdir(root) do
+  run!('html2rss', 'validate', config.to_s, env: env)
+  rss = run!('html2rss', 'feed', config.to_s, env: env, quiet: true)
+  items = count_items(rss)
+  puts "items #{items}"
+  abort('Feed produced zero <item> elements') if items.zero?
+
+  titles = rss.scan(%r{<title>(.*?)</title>}m).flatten.drop(1).first(5)
+  titles.each { |t| puts "  - #{t.gsub(/<!\[CDATA\[|\]\]>/, '').strip}" }
+
+  if fetch
+    cmd = ['bundle', 'exec', 'rspec', '--tag', 'fetch', '--example', example,
+           'spec/html2rss/configs_dynamic_spec.rb']
+    run!(*cmd, env: env)
+  end
+end
+
+puts "ok #{example}"

--- a/.agents/skills/html2rss-config/scripts/check_config
+++ b/.agents/skills/html2rss-config/scripts/check_config
@@ -37,9 +37,37 @@ def feed_example_name(config_path, root)
   config_path.relative_path_from(root / 'lib/html2rss/configs').to_s
 end
 
-def run!(*cmd, env: {}, quiet: false)
+# Prefer PATH `html2rss`, then sibling ../html2rss (exe via bundle, then bin).
+def resolve_html2rss_invocation(root)
+  path_bin = `command -v html2rss 2>/dev/null`.strip
+  return ['html2rss'] unless path_bin.empty?
+
+  sibling = root.parent / 'html2rss'
+  exe = sibling / 'exe' / 'html2rss'
+  if exe.file?
+    return ['bundle', 'exec', exe.to_s] if (sibling / 'Gemfile').file?
+
+    return [exe.to_s]
+  end
+
+  bin = sibling / 'bin' / 'html2rss'
+  if bin.file?
+    return ['bundle', 'exec', bin.to_s] if (sibling / 'Gemfile').file?
+
+    return [bin.to_s]
+  end
+
+  abort(<<~MSG)
+    html2rss CLI not found on PATH and no sibling checkout at #{sibling}.
+    Install the CLI or clone html2rss next to html2rss-configs (AGENTS.md).
+  MSG
+end
+
+def run!(*cmd, env: {}, quiet: false, chdir: nil)
   puts "+ #{cmd.join(' ')}"
-  out, status = Open3.capture2e(env, *cmd)
+  opts = {}
+  opts[:chdir] = chdir if chdir
+  out, status = Open3.capture2e(env, *cmd, **opts)
   puts out unless quiet
   abort("Command failed (#{status.exitstatus}): #{cmd.join(' ')}\n#{out}") unless status.success?
   out
@@ -58,12 +86,14 @@ usage! unless ARGV.size == 1
 root = repo_root
 config = resolve_config(ARGV.fetch(0), root)
 example = feed_example_name(config, root)
+cli = resolve_html2rss_invocation(root)
+cli_chdir = cli.first == 'bundle' ? (root.parent / 'html2rss').to_s : nil
 env = {}
 env['BOTASAURUS_SCRAPER_URL'] = ENV.fetch('BOTASAURUS_SCRAPER_URL', 'http://localhost:4010') if botasaurus
 
 Dir.chdir(root) do
-  run!('html2rss', 'validate', config.to_s, env: env)
-  rss = run!('html2rss', 'feed', config.to_s, env: env, quiet: true)
+  run!(*cli, 'validate', config.to_s, env: env, chdir: cli_chdir)
+  rss = run!(*cli, 'feed', config.to_s, env: env, quiet: true, chdir: cli_chdir)
   items = count_items(rss)
   puts "items #{items}"
   abort('Feed produced zero <item> elements') if items.zero?

--- a/.agents/skills/html2rss-config/scripts/probe_rss
+++ b/.agents/skills/html2rss-config/scripts/probe_rss
@@ -122,41 +122,50 @@ def syndication_type?(type)
 end
 
 def feed_like_href?(href)
-  href.match?(%r{rss|atom|feed|\.xml}i)
+  href.match?(/rss|atom|feed|\.xml/i)
+end
+
+def alternate_rel?(tag)
+  tag[REL_RE, 1].to_s.downcase.split(/\s+/).include?('alternate')
+end
+
+def href_from_alternate_link(tag, page_url)
+  return unless alternate_rel?(tag)
+
+  href = tag[HREF_RE, 1]
+  return if href.nil? || href.empty?
+  return unless syndication_type?(tag[TYPE_RE, 1]) || feed_like_href?(href)
+
+  absolute_url(page_url, href.strip)
 end
 
 def alternate_feed_hrefs(html, page_url)
   return [] if html.nil? || html.empty?
 
-  html.scan(LINK_TAG_RE).filter_map do |tag|
-    rel = tag[REL_RE, 1].to_s.downcase
-    next unless rel.split(/\s+/).include?('alternate')
+  html.scan(LINK_TAG_RE).filter_map { |tag| href_from_alternate_link(tag, page_url) }.uniq
+end
 
-    href = tag[HREF_RE, 1]
-    next if href.nil? || href.empty?
+def first_feedish_url(urls)
+  urls.lazy.filter_map do |url|
+    res, final = fetch(url)
+    final if feedish?(res)
+  end.first
+end
 
-    type = tag[TYPE_RE, 1]
-    next unless syndication_type?(type) || feed_like_href?(href)
-
-    absolute_url(page_url, href.strip)
-  end.uniq
+def page_fetch_context(page)
+  page_res, final_page = fetch(page)
+  page_url = ok_response?(page_res) ? final_page : page
+  html = ok_response?(page_res) ? page_res.body.to_s : ''
+  [page_url, html]
 end
 
 def find_feed(page, extra)
-  page_res, final_page = fetch(page)
-  page_url = ok_response?(page_res) ? final_page : page
-  page_html = ok_response?(page_res) ? page_res.body.to_s : ''
-
-  alternate_feed_hrefs(page_html, page_url).each do |candidate|
-    res, final = fetch(candidate)
-    return final if feedish?(res)
-  end
+  page_url, html = page_fetch_context(page)
+  hit = first_feedish_url(alternate_feed_hrefs(html, page_url))
+  return hit if hit
 
   paths = (page_dir_paths(page_url) + DEFAULT_PATHS + extra).uniq
-  paths.lazy.filter_map do |path|
-    res, final = fetch(absolute_url(page_url, path))
-    final if feedish?(res)
-  end.first
+  first_feedish_url(paths.map { |path| absolute_url(page_url, path) })
 end
 
 usage! if ARGV.empty? || ARGV.include?('-h') || ARGV.include?('--help')

--- a/.agents/skills/html2rss-config/scripts/probe_rss
+++ b/.agents/skills/html2rss-config/scripts/probe_rss
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Probe common first-party RSS/Atom paths for a page or origin URL.
+# Exit 0 = no feed found (curated config may add value).
+# Exit 3 = feed found (print URL; consider dropping per AGENTS.md).
+# Exit 1 = usage / request error.
+#
+# Usage:
+#   .agents/skills/html2rss-config/scripts/probe_rss 'https://example.com/news/'
+#   .agents/skills/html2rss-config/scripts/probe_rss 'https://example.com' /feed /rss.xml
+
+require 'net/http'
+require 'uri'
+
+UA = 'html2rss-config-probe_rss/1.0'
+DEFAULT_PATHS = %w[
+  /feed
+  /feed.xml
+  /rss
+  /rss.xml
+  /atom.xml
+  /index.xml
+  /news/rss
+  /news/feed
+  /blog/feed
+  /blog/rss.xml
+].freeze
+FEED_CT_MARKERS = %w[xml rss atom].freeze
+FEED_BODY_MARKERS = %w[<rss <feed xmlns:atom].freeze
+
+def usage!
+  warn <<~USAGE
+    Usage: probe_rss <page-or-origin-url> [extra/path ...]
+  USAGE
+  exit 1
+end
+
+def http_client(uri)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = uri.scheme == 'https'
+  http.open_timeout = 8
+  http.read_timeout = 12
+  http
+end
+
+def get_request(uri)
+  req = Net::HTTP::Get.new(uri)
+  req['User-Agent'] = UA
+  req['Accept'] = 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*'
+  req
+end
+
+def follow_redirect(url, res)
+  loc = URI.join(url, res['location'])
+  [http_client(loc).request(get_request(loc)), loc.to_s]
+end
+
+def fetch(url)
+  uri = URI(url)
+  res = http_client(uri).request(get_request(uri))
+  4.times do
+    break unless res.is_a?(Net::HTTPRedirection)
+
+    res, url = follow_redirect(url, res)
+  end
+  [res, url]
+rescue StandardError => error
+  [error, url]
+end
+
+def ok_response?(res)
+  res.respond_to?(:code) && res.code.to_i.between?(200, 299)
+end
+
+def feedish?(res)
+  return false unless ok_response?(res)
+
+  ct = (res['content-type'] || '').downcase
+  return true if FEED_CT_MARKERS.any? { |marker| ct.include?(marker) }
+
+  body = res.body.to_s[0, 800].downcase
+  FEED_BODY_MARKERS.any? { |marker| body.include?(marker) }
+end
+
+def page_dir_paths(page)
+  path = URI(page).path
+  return [] if path.nil? || path.empty? || path == '/'
+
+  dir = path.sub(%r{/[^/]*$}, '/')
+  ["#{dir}feed", "#{dir}rss.xml", "#{dir}atom.xml"]
+end
+
+def absolute_url(base, path)
+  return path if path.start_with?('http')
+
+  "#{base}#{path.start_with?('/') ? path : "/#{path}"}"
+end
+
+def find_feed(page, extra)
+  base = URI.join(page, '/').to_s.chomp('/')
+  paths = (page_dir_paths(page) + DEFAULT_PATHS + extra).uniq
+  paths.lazy.filter_map do |path|
+    res, final = fetch(absolute_url(base, path))
+    final if feedish?(res)
+  end.first
+end
+
+usage! if ARGV.empty? || ARGV.include?('-h') || ARGV.include?('--help')
+
+page = ARGV.fetch(0)
+hit = find_feed(page, ARGV.drop(1))
+
+if hit
+  puts "HAS_RSS\t#{hit}"
+  exit 3
+end
+
+puts "NO_RSS\t#{page}"
+exit 0

--- a/.agents/skills/html2rss-config/scripts/probe_rss
+++ b/.agents/skills/html2rss-config/scripts/probe_rss
@@ -1,10 +1,16 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Probe common first-party RSS/Atom paths for a page or origin URL.
+# Probe first-party RSS/Atom for a page or origin URL.
+# 1) Fetch the page and parse <link rel="alternate" …> feed hints.
+# 2) Fall back to common feed path guesses (+ optional extra paths).
+#
 # Exit 0 = no feed found (curated config may add value).
 # Exit 3 = feed found (print URL; consider dropping per AGENTS.md).
 # Exit 1 = usage / request error.
+#
+# Notes for agents: exit 3 is intentional success-for-"has feed". Under `set -e`,
+# check explicitly (`probe_rss …; status=$?`) — do not treat 3 as a shell failure.
 #
 # Usage:
 #   .agents/skills/html2rss-config/scripts/probe_rss 'https://example.com/news/'
@@ -28,6 +34,10 @@ DEFAULT_PATHS = %w[
 ].freeze
 FEED_CT_MARKERS = %w[xml rss atom].freeze
 FEED_BODY_MARKERS = %w[<rss <feed xmlns:atom].freeze
+LINK_TAG_RE = /<link\b[^>]*>/i
+HREF_RE = /\bhref\s*=\s*["']([^"']+)["']/i
+TYPE_RE = /\btype\s*=\s*["']([^"']+)["']/i
+REL_RE = /\brel\s*=\s*["']([^"']+)["']/i
 
 def usage!
   warn <<~USAGE
@@ -47,7 +57,7 @@ end
 def get_request(uri)
   req = Net::HTTP::Get.new(uri)
   req['User-Agent'] = UA
-  req['Accept'] = 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*'
+  req['Accept'] = 'application/rss+xml, application/atom+xml, application/xml, text/xml, text/html, */*'
   req
 end
 
@@ -94,14 +104,57 @@ end
 def absolute_url(base, path)
   return path if path.start_with?('http')
 
-  "#{base}#{path.start_with?('/') ? path : "/#{path}"}"
+  origin = URI.join(base, '/').to_s.chomp('/')
+  return "#{origin}#{path}" if path.start_with?('/')
+
+  URI.join("#{origin}/", path).to_s
+rescue StandardError
+  origin = base.to_s.sub(%r{/[^/]*$}, '')
+  origin = base.to_s if origin.empty?
+  "#{origin.chomp('/')}#{path.start_with?('/') ? path : "/#{path}"}"
+end
+
+def syndication_type?(type)
+  return false if type.nil? || type.empty?
+
+  t = type.downcase
+  t.include?('rss+xml') || t.include?('atom+xml') || t.include?('rss') || t.include?('atom')
+end
+
+def feed_like_href?(href)
+  href.match?(%r{rss|atom|feed|\.xml}i)
+end
+
+def alternate_feed_hrefs(html, page_url)
+  return [] if html.nil? || html.empty?
+
+  html.scan(LINK_TAG_RE).filter_map do |tag|
+    rel = tag[REL_RE, 1].to_s.downcase
+    next unless rel.split(/\s+/).include?('alternate')
+
+    href = tag[HREF_RE, 1]
+    next if href.nil? || href.empty?
+
+    type = tag[TYPE_RE, 1]
+    next unless syndication_type?(type) || feed_like_href?(href)
+
+    absolute_url(page_url, href.strip)
+  end.uniq
 end
 
 def find_feed(page, extra)
-  base = URI.join(page, '/').to_s.chomp('/')
-  paths = (page_dir_paths(page) + DEFAULT_PATHS + extra).uniq
+  page_res, final_page = fetch(page)
+  page_url = ok_response?(page_res) ? final_page : page
+  page_html = ok_response?(page_res) ? page_res.body.to_s : ''
+
+  alternate_feed_hrefs(page_html, page_url).each do |candidate|
+    res, final = fetch(candidate)
+    return final if feedish?(res)
+  end
+
+  paths = (page_dir_paths(page_url) + DEFAULT_PATHS + extra).uniq
   paths.lazy.filter_map do |path|
-    res, final = fetch(absolute_url(base, path))
+    res, final = fetch(absolute_url(page_url, path))
     final if feedish?(res)
   end.first
 end

--- a/.agents/skills/html2rss-config/scripts/register_botasaurus
+++ b/.agents/skills/html2rss-config/scripts/register_botasaurus
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Idempotently add a config path to spec/support/botasaurus_fetch_configs.rb (sorted).
+# Usage (from repo root):
+#   .agents/skills/html2rss-config/scripts/register_botasaurus domain/file.yml
+#   .agents/skills/html2rss-config/scripts/register_botasaurus lib/html2rss/configs/domain/file.yml
+
+require 'pathname'
+
+def usage!
+  warn <<~USAGE
+    Usage: register_botasaurus <domain/file.yml>
+  USAGE
+  exit 1
+end
+
+def repo_root
+  Pathname.new(__dir__).ascend.find { |p| (p / 'spec/support/botasaurus_fetch_configs.rb').file? } ||
+    abort('Could not find html2rss-configs repo root')
+end
+
+def normalize_name(arg, root)
+  rel = arg.to_s.split('lib/html2rss/configs/', 2).last.delete_prefix('/').delete_prefix('./')
+  abort('Expected something like domain/file.yml') unless rel.match?(%r{\A[^/]+/.+\.yml\z})
+
+  warn "Warning: missing #{root / 'lib/html2rss/configs' / rel}" unless (root / 'lib/html2rss/configs' / rel).file?
+  rel
+end
+
+usage! if ARGV.size != 1 || ARGV.include?('-h') || ARGV.include?('--help')
+
+root = repo_root
+name = normalize_name(ARGV.fetch(0), root)
+registry = root / 'spec/support/botasaurus_fetch_configs.rb'
+text = registry.read
+
+unless text =~ /CONFIGS = %w\[(.*?)\].freeze/m
+  abort('Could not find CONFIGS = %w[ ... ].freeze in botasaurus_fetch_configs.rb')
+end
+
+body = Regexp.last_match(1)
+entries = body.scan(%r{^\s*([a-z0-9._-]+/[a-z0-9._/-]+\.yml)\s*$}i).flatten
+if entries.include?(name)
+  puts "already_registered #{name}"
+  exit 0
+end
+
+entries << name
+entries.sort!
+new_body = entries.map { |e| "    #{e}" }.join("\n")
+new_text = text.sub(/CONFIGS = %w\[.*?\].freeze/m, "CONFIGS = %w[\n#{new_body}\n  ].freeze")
+
+registry.write(new_text)
+puts "registered #{name}"

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem 'html2rss', github: 'html2rss/html2rss', branch: :master
+gem 'html2rss', '~> 0.26'
 
 group :development do
   gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,3 @@
-GIT
-  remote: https://github.com/html2rss/html2rss
-  revision: aa974733c6e88a5c934f445516d9752dfa316067
-  branch: master
-  specs:
-    html2rss (0.25.0)
-      addressable (~> 2.7)
-      brotli
-      dry-validation
-      faraday (> 2.0.1, < 3.0)
-      faraday-follow_redirects
-      faraday-gzip (~> 3)
-      kramdown
-      mcp (~> 1.0)
-      mime-types (> 3.0)
-      nokogiri (>= 1.10, < 2.0)
-      rack (~> 3.0)
-      rackup (~> 2.0)
-      regexp_parser
-      reverse_markdown (~> 3.0)
-      rss
-      sanitize
-      thor
-      tzinfo
-      webrick (~> 1.9)
-      zeitwerk
-
 PATH
   remote: .
   specs:
@@ -89,6 +62,27 @@ GEM
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     hana (1.3.7)
+    html2rss (0.26.0)
+      addressable (~> 2.7)
+      brotli
+      dry-validation
+      faraday (> 2.0.1, < 3.0)
+      faraday-follow_redirects
+      faraday-gzip (~> 3)
+      kramdown
+      mcp (~> 1.0)
+      mime-types (> 3.0)
+      nokogiri (>= 1.10, < 2.0)
+      rack (~> 3.0)
+      rackup (~> 2.0)
+      regexp_parser
+      reverse_markdown (~> 3.0)
+      rss
+      sanitize
+      thor
+      tzinfo
+      webrick (~> 1.9)
+      zeitwerk
     json (2.21.2)
     json_schemer (2.5.0)
       bigdecimal
@@ -187,7 +181,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  html2rss!
+  html2rss (~> 0.26)
   html2rss-configs!
   nokogiri
   public_suffix

--- a/lib/html2rss/configs/ai.meta.com/blog.yml
+++ b/lib/html2rss/configs/ai.meta.com/blog.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - research
+channel:
+  url: https://ai.meta.com/blog/
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[href*="/blog/"][aria-label^="Read "]'
+    enhance: false
+  title:
+    extractor: attribute
+    attribute: aria-label
+    post_process:
+      - name: gsub
+        pattern: "/^Read\\s+/"
+        replacement: ""
+  url:
+    extractor: href

--- a/lib/html2rss/configs/anthropic.com/news.yml
+++ b/lib/html2rss/configs/anthropic.com/news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - research
+channel:
+  url: https://www.anthropic.com/news
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'ul[class*="PublicationList"] > li > a[href^="/news/"]'
+    enhance: false
+  title:
+    selector: '[class*="__title"]'
+  url:
+    extractor: href

--- a/lib/html2rss/configs/anu.edu.au/news.yml
+++ b/lib/html2rss/configs/anu.edu.au/news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
+    - research
+channel:
+  url: https://www.anu.edu.au/news/all-news
+  language: en
+  time_zone: Australia/Sydney
+  ttl: 360
+selectors:
+  items:
+    selector: 'h3 a[href*="/news/all-news/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/asml.com/press-releases.yml
+++ b/lib/html2rss/configs/asml.com/press-releases.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - product
+channel:
+  url: https://www.asml.com/en/news/press-releases
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'a.related-content-card[href*="/en/news/press-releases/"]'
+    enhance: false
+  title:
+    selector: .related-content-card-title
+  url:
+    extractor: href

--- a/lib/html2rss/configs/aspi.org.au/strategist.yml
+++ b/lib/html2rss/configs/aspi.org.au/strategist.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - research
+strategy: botasaurus
+
+channel:
+  url: https://www.aspi.org.au/strategist-posts/
+  language: en
+  time_zone: Australia/Sydney
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'a[rel="bookmark"][href*="/strategist-posts/"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'a[rel="bookmark"][href*="/strategist-posts/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/brookings.edu/articles.yml
+++ b/lib/html2rss/configs/brookings.edu/articles.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - research
+channel:
+  url: https://www.brookings.edu/
+  language: en
+  time_zone: America/New_York
+  ttl: 360
+selectors:
+  items:
+    selector: 'a.overlay-link[href*="/articles/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/bundesregierung.de/pressemitteilungen.yml
+++ b/lib/html2rss/configs/bundesregierung.de/pressemitteilungen.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+strategy: botasaurus
+
+channel:
+  url: https://www.bundesregierung.de/breg-de/aktuelles/pressemitteilungen
+  language: de
+  time_zone: Europe/Berlin
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'a.bpa-link[href*="/aktuelles/pressemitteilungen/"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'a.bpa-link[href*="/breg-de/aktuelles/pressemitteilungen/"]'
+    enhance: false
+  title:
+    selector: span.bpa-teaser-title-text-inner
+  url:
+    extractor: href

--- a/lib/html2rss/configs/carnegieendowment.org/research.yml
+++ b/lib/html2rss/configs/carnegieendowment.org/research.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - research
+strategy: botasaurus
+
+channel:
+  url: https://carnegieendowment.org/research
+  language: en
+  time_zone: UTC
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'a.min-w-0.flex-1[href^="/research/20"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'a.min-w-0.flex-1[href^="/research/20"]'
+    enhance: false
+  title:
+    selector: span.text-headlineH5
+  url:
+    extractor: href

--- a/lib/html2rss/configs/chathamhouse.org/research-publications.yml
+++ b/lib/html2rss/configs/chathamhouse.org/research-publications.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - research
+strategy: botasaurus
+
+channel:
+  url: https://www.chathamhouse.org/publications/research-publications
+  language: en
+  time_zone: Europe/London
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: a.teaser__link
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: a.teaser__link
+    enhance: false
+  title:
+    selector: .teaser__title
+  url:
+    extractor: href

--- a/lib/html2rss/configs/cohere.com/blog.yml
+++ b/lib/html2rss/configs/cohere.com/blog.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - research
+channel:
+  url: https://cohere.com/blog
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[href^="/blog/"][class*="flex-1"]'
+    enhance: false
+  title:
+    selector: '> p:first-of-type'
+  url:
+    extractor: href

--- a/lib/html2rss/configs/cohere.com/blog.yml
+++ b/lib/html2rss/configs/cohere.com/blog.yml
@@ -13,6 +13,6 @@ selectors:
     selector: 'a[href^="/blog/"][class*="flex-1"]'
     enhance: false
   title:
-    selector: '> p:first-of-type'
+    selector: "> p:first-of-type"
   url:
     extractor: href

--- a/lib/html2rss/configs/csiro.au/news.yml
+++ b/lib/html2rss/configs/csiro.au/news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
+    - research
+channel:
+  url: https://www.csiro.au/en/news
+  language: en
+  time_zone: Australia/Sydney
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[href*="/en/news/All/Articles/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/curia.europa.eu/press-releases.yml
+++ b/lib/html2rss/configs/curia.europa.eu/press-releases.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+strategy: botasaurus
+
+channel:
+  url: https://curia.europa.eu/jcms/jcms/Jo2_7052/
+  language: en
+  time_zone: Europe/Brussels
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: li.curia-itemlist-item
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: li.curia-itemlist-item
+    enhance: false
+  title:
+    selector: .curia-itemlist-item-title h3
+  url:
+    selector: .curia-itemlist-item-title a
+    extractor: href

--- a/lib/html2rss/configs/elysee.fr/actualites.yml
+++ b/lib/html2rss/configs/elysee.fr/actualites.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+channel:
+  url: https://www.elysee.fr/toutes-les-actualites
+  language: fr
+  time_zone: Europe/Paris
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[href*="/emmanuel-macron/20"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/ethz.ch/eth-news.yml
+++ b/lib/html2rss/configs/ethz.ch/eth-news.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
+    - research
+strategy: botasaurus
+
+channel:
+  url: https://ethz.ch/en/news-and-events/eth-news.html
+  language: en
+  time_zone: Europe/Zurich
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'a[href*="/eth-news/news/20"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'a[href*="/eth-news/news/20"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/faa.gov/newsroom.yml
+++ b/lib/html2rss/configs/faa.gov/newsroom.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+channel:
+  url: https://www.faa.gov/newsroom
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: '.views-row a[href^="/newsroom/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/fao.org/newsroom.yml
+++ b/lib/html2rss/configs/fao.org/newsroom.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - environment
+    - civic
+channel:
+  url: https://www.fao.org/newsroom/en
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[href*="/newsroom/detail/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/figma.com/blog.yml
+++ b/lib/html2rss/configs/figma.com/blog.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - product
+channel:
+  url: https://www.figma.com/blog/
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: article[aria-label]
+    enhance: false
+  title:
+    extractor: attribute
+    attribute: aria-label
+  url:
+    selector: 'a[href*="/blog/"]'
+    extractor: href

--- a/lib/html2rss/configs/ftc.gov/press-releases.yml
+++ b/lib/html2rss/configs/ftc.gov/press-releases.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - security
+    - civic
+channel:
+  url: https://www.ftc.gov/news-events/news/press-releases
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[href*="/news-events/news/press-releases/20"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/haaretz.com/israel-news.yml
+++ b/lib/html2rss/configs/haaretz.com/israel-news.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+channel:
+  url: https://www.haaretz.com/israel-news
+  language: en
+  time_zone: Asia/Jerusalem
+  ttl: 360
+selectors:
+  items:
+    selector: 'h3 a[href*="/ty-article"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/hai.stanford.edu/news.yml
+++ b/lib/html2rss/configs/hai.stanford.edu/news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
+    - research
+channel:
+  url: https://hai.stanford.edu/news
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[class*="titleLink"][href*="/news/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/icj-cij.org/press-releases.yml
+++ b/lib/html2rss/configs/icj-cij.org/press-releases.yml
@@ -14,5 +14,5 @@ selectors:
   title:
     selector: .views-field-field-document-long-title
   url:
-    selector: '.views-field-field-press-release-number a'
+    selector: ".views-field-field-press-release-number a"
     extractor: href

--- a/lib/html2rss/configs/icj-cij.org/press-releases.yml
+++ b/lib/html2rss/configs/icj-cij.org/press-releases.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+channel:
+  url: https://www.icj-cij.org/press-releases
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: .views-row
+    enhance: false
+  title:
+    selector: .views-field-field-document-long-title
+  url:
+    selector: '.views-field-field-press-release-number a'
+    extractor: href

--- a/lib/html2rss/configs/icrc.org/news.yml
+++ b/lib/html2rss/configs/icrc.org/news.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+channel:
+  url: https://www.icrc.org/en/news
+  language: en
+  time_zone: Europe/Zurich
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[href^="/en/article/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/iea.org/news.yml
+++ b/lib/html2rss/configs/iea.org/news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - energy
+    - environment
+channel:
+  url: https://www.iea.org/news
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'a.m-news-detailed-listing__link[href^="/news/"]'
+    enhance: false
+  title:
+    selector: .m-news-detailed-listing__title
+  url:
+    extractor: href

--- a/lib/html2rss/configs/iiss.org/online-analysis.yml
+++ b/lib/html2rss/configs/iiss.org/online-analysis.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - research
+strategy: botasaurus
+
+channel:
+  url: https://www.iiss.org/online-analysis
+  language: en
+  time_zone: Europe/London
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'a.feature[href*="/online-analysis/"][href*="/20"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'a.feature[href*="/online-analysis/"][href*="/20"]'
+    enhance: false
+  title:
+    selector: h2
+  url:
+    extractor: href

--- a/lib/html2rss/configs/imo.org/press-briefings.yml
+++ b/lib/html2rss/configs/imo.org/press-briefings.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+strategy: botasaurus
+
+channel:
+  url: https://www.imo.org/en/MediaCentre/PressBriefings/Pages/default.aspx
+  language: en
+  time_zone: UTC
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'h3 a[href*="/PressBriefings/pages/"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'h3 a[href*="/PressBriefings/pages/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/imperial.ac.uk/news.yml
+++ b/lib/html2rss/configs/imperial.ac.uk/news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
+    - research
+channel:
+  url: https://www.imperial.ac.uk/news/articles/
+  language: en
+  time_zone: Europe/London
+  ttl: 360
+selectors:
+  items:
+    selector: 'a.listing-item[href*="/news/articles/"]'
+    enhance: false
+  title:
+    selector: .listing-item__title
+  url:
+    extractor: href

--- a/lib/html2rss/configs/isro.gov.in/press.yml
+++ b/lib/html2rss/configs/isro.gov.in/press.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
+    - research
+channel:
+  url: https://www.isro.gov.in/Press.html
+  language: en
+  time_zone: Asia/Kolkata
+  ttl: 360
+selectors:
+  items:
+    selector: 'table tr a[href$=".html"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/kaist.ac.kr/news.yml
+++ b/lib/html2rss/configs/kaist.ac.kr/news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
+    - research
+channel:
+  url: https://news.kaist.ac.kr/newsen/html/news/
+  language: en
+  time_zone: Asia/Seoul
+  ttl: 360
+selectors:
+  items:
+    selector: 'a.lay[href*="mng_no="]'
+    enhance: false
+  title:
+    selector: strong.tis
+  url:
+    extractor: href

--- a/lib/html2rss/configs/machinelearning.apple.com/research.yml
+++ b/lib/html2rss/configs/machinelearning.apple.com/research.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - research
+channel:
+  url: https://machinelearning.apple.com/research/
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'ul.article-list > li.post-row > div > a.post-link'
+    enhance: false
+  title:
+    selector: h3.post-title
+  url:
+    extractor: href

--- a/lib/html2rss/configs/machinelearning.apple.com/research.yml
+++ b/lib/html2rss/configs/machinelearning.apple.com/research.yml
@@ -10,7 +10,7 @@ channel:
   ttl: 360
 selectors:
   items:
-    selector: 'ul.article-list > li.post-row > div > a.post-link'
+    selector: "ul.article-list > li.post-row > div > a.post-link"
     enhance: false
   title:
     selector: h3.post-title

--- a/lib/html2rss/configs/mistral.ai/news.yml
+++ b/lib/html2rss/configs/mistral.ai/news.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - tech
+    - research
+channel:
+  url: https://mistral.ai/news/
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: article.js-post
+    enhance: false
+  title:
+    selector: h2.js-post-title
+  url:
+    selector: a[href^="/news/"]
+    extractor: href

--- a/lib/html2rss/configs/msf.org/latest.yml
+++ b/lib/html2rss/configs/msf.org/latest.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+    - civic
+channel:
+  url: https://www.msf.org/latest-portal
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: a.card__title-link
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/news.cn/latest.yml
+++ b/lib/html2rss/configs/news.cn/latest.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+channel:
+  url: https://english.news.cn/list/latestnews.htm
+  language: en
+  time_zone: Asia/Shanghai
+  ttl: 360
+selectors:
+  items:
+    selector: '#list .item .tit a'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/news.cn/latest.yml
+++ b/lib/html2rss/configs/news.cn/latest.yml
@@ -9,7 +9,7 @@ channel:
   ttl: 360
 selectors:
   items:
-    selector: '#list .item .tit a'
+    selector: "#list .item .tit a"
     enhance: false
   title:
     extractor: text

--- a/lib/html2rss/configs/nikkei.com/asia-technology.yml
+++ b/lib/html2rss/configs/nikkei.com/asia-technology.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+    - tech
+channel:
+  url: https://asia.nikkei.com/business/technology
+  language: en
+  time_zone: Asia/Tokyo
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[data-trackable="headline"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/ntu.edu.sg/news.yml
+++ b/lib/html2rss/configs/ntu.edu.sg/news.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
+    - research
+strategy: botasaurus
+
+channel:
+  url: https://www.ntu.edu.sg/news
+  language: en
+  time_zone: Asia/Singapore
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'a.img-card[href*="/news/detail/"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'a.img-card[href*="/news/detail/"]'
+    enhance: false
+  title:
+    selector: .img-card__title
+  url:
+    extractor: href

--- a/lib/html2rss/configs/occrp.org/news.yml
+++ b/lib/html2rss/configs/occrp.org/news.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+    - civic
+strategy: botasaurus
+
+channel:
+  url: https://www.occrp.org/en/news
+  language: en
+  time_zone: UTC
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: article.news-item
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: article.news-item
+    enhance: false
+  title:
+    selector: h3.news-item__title a
+  url:
+    selector: h3.news-item__title a
+    extractor: href

--- a/lib/html2rss/configs/oecd.org/newsroom.yml
+++ b/lib/html2rss/configs/oecd.org/newsroom.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - finance
+    - civic
+strategy: botasaurus
+
+channel:
+  url: https://www.oecd.org/en/about/newsroom.html
+  language: en
+  time_zone: UTC
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'a[href*="/en/about/news/press-releases/"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'a.card__title-link[href*="/en/about/news/press-releases/"], a.cmp-featured-card__link[href*="/en/about/news/press-releases/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/opec.org/press-releases.yml
+++ b/lib/html2rss/configs/opec.org/press-releases.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - energy
+    - civic
+strategy: botasaurus
+
+channel:
+  url: https://www.opec.org/press-releases.html
+  language: en
+  time_zone: Europe/Vienna
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'div.pritem a[href*="pr-detail"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: div.pritem
+    enhance: false
+  title:
+    selector: h1
+  url:
+    selector: 'a[href*="pr-detail"]'
+    extractor: href

--- a/lib/html2rss/configs/sipri.org/news.yml
+++ b/lib/html2rss/configs/sipri.org/news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - research
+channel:
+  url: https://www.sipri.org/news
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'h3.field-content a[href^="/news/20"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/thenationalnews.com/news.yml
+++ b/lib/html2rss/configs/thenationalnews.com/news.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+channel:
+  url: https://www.thenationalnews.com/news/
+  language: en
+  time_zone: Asia/Dubai
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[href*="/news/"][href*="/202"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/who.int/news.yml
+++ b/lib/html2rss/configs/who.int/news.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
+    - civic
+strategy: botasaurus
+
+channel:
+  url: https://www.who.int/news
+  language: en
+  time_zone: UTC
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'a.link-container[href*="/news/item/"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'a.link-container[href*="/news/item/"]'
+    enhance: false
+  title:
+    extractor: attribute
+    attribute: aria-label
+  url:
+    extractor: href

--- a/lib/html2rss/configs/worldbank.org/news.yml
+++ b/lib/html2rss/configs/worldbank.org/news.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - finance
+    - civic
+strategy: botasaurus
+
+channel:
+  url: https://www.worldbank.org/ext/en/news
+  language: en
+  time_zone: UTC
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'a.button[href*="/news/press-release/"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'a.button[href*="/news/press-release/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/www.consilium.europa.eu/press-releases.yml
+++ b/lib/html2rss/configs/www.consilium.europa.eu/press-releases.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+strategy: botasaurus
+
+channel:
+  url: https://www.consilium.europa.eu/en/press/press-releases/
+  language: en
+  time_zone: UTC
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'a.gsc-excerpt-item__link[href*="/press/press-releases/"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'a.gsc-excerpt-item__link[href*="/en/press/press-releases/20"]'
+    enhance: false
+  title:
+    selector: span.gsc-excerpt-item__title
+  url:
+    extractor: href

--- a/lib/html2rss/configs/www.ecdc.europa.eu/news-events.yml
+++ b/lib/html2rss/configs/www.ecdc.europa.eu/news-events.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - science
+    - civic
+channel:
+  url: https://www.ecdc.europa.eu/en/news-events
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[href^="/en/news-events/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/www.enisa.europa.eu/news.yml
+++ b/lib/html2rss/configs/www.enisa.europa.eu/news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - security
+    - civic
+channel:
+  url: https://www.enisa.europa.eu/news
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'h3 a[href^="/news/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/www.europarl.europa.eu/press-room.yml
+++ b/lib/html2rss/configs/www.europarl.europa.eu/press-room.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+strategy: botasaurus
+
+channel:
+  url: https://www.europarl.europa.eu/news/en/press-room
+  language: en
+  time_zone: UTC
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'a[href*="/news/en/press-room/"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'a[href*="/news/en/press-room/"][title="Read more"]'
+    enhance: false
+  title:
+    selector: span.ep_name
+  url:
+    extractor: href

--- a/spec/support/botasaurus_fetch_configs.rb
+++ b/spec/support/botasaurus_fetch_configs.rb
@@ -3,10 +3,17 @@
 module BotasaurusFetchConfigs
   CONFIGS = %w[
     apple.com/newsroom.yml
+    bundesregierung.de/pressemitteilungen.yml
+    carnegieendowment.org/research.yml
     imdb.com/ratings.yml
+    oecd.org/newsroom.yml
     stackoverflow.com/hot_network_questions.yml
     support.apple.com/en_gb_ht201222.yml
     thoughtworks.com/insights.yml
+    who.int/news.yml
+    worldbank.org/news.yml
+    www.consilium.europa.eu/press-releases.yml
+    www.europarl.europa.eu/press-room.yml
   ].freeze
 
   module_function

--- a/spec/support/botasaurus_fetch_configs.rb
+++ b/spec/support/botasaurus_fetch_configs.rb
@@ -3,10 +3,16 @@
 module BotasaurusFetchConfigs
   CONFIGS = %w[
     apple.com/newsroom.yml
+    aspi.org.au/strategist.yml
     bundesregierung.de/pressemitteilungen.yml
     carnegieendowment.org/research.yml
+    chathamhouse.org/research-publications.yml
+    ethz.ch/eth-news.yml
+    iiss.org/online-analysis.yml
     imdb.com/ratings.yml
+    ntu.edu.sg/news.yml
     oecd.org/newsroom.yml
+    opec.org/press-releases.yml
     stackoverflow.com/hot_network_questions.yml
     support.apple.com/en_gb_ht201222.yml
     thoughtworks.com/insights.yml

--- a/spec/support/botasaurus_fetch_configs.rb
+++ b/spec/support/botasaurus_fetch_configs.rb
@@ -7,10 +7,13 @@ module BotasaurusFetchConfigs
     bundesregierung.de/pressemitteilungen.yml
     carnegieendowment.org/research.yml
     chathamhouse.org/research-publications.yml
+    curia.europa.eu/press-releases.yml
     ethz.ch/eth-news.yml
     iiss.org/online-analysis.yml
     imdb.com/ratings.yml
+    imo.org/press-briefings.yml
     ntu.edu.sg/news.yml
+    occrp.org/news.yml
     oecd.org/newsroom.yml
     opec.org/press-releases.yml
     stackoverflow.com/hot_network_questions.yml


### PR DESCRIPTION
## What changed

- Added ~45 curated YAML feed configs under `lib/html2rss/configs/` with `directory.topics`, across phased batches: AI/cyber, IGO/finance, Asia/ME/science, think tanks / Oz-Asia, and industry regulators/agencies.
- Registered Botasaurus-backed candidates in `spec/support/botasaurus_fetch_configs.rb` where Faraday fetch is unreliable.
- Added `.agents/skills/html2rss-config/` create/repair skill, topic reference, and helper scripts (`check_config`, `probe_rss`, `register_botasaurus`) to support the expansion workflow.

## Why

Grow the packaged catalog with stable primary and industry newsroom surfaces that lack (or add curated value over) first-party RSS, while tagging each feed for the directory topics vocabulary. Agent skill/helpers are included so future config work follows the same gate (validate → feed → fetch).

## Risk

- Selector drift on JS-heavy or localized newsrooms; several configs are Botasaurus-backed and need `BOTASAURUS_SCRAPER_URL=http://localhost:4010` for fetch specs.
- Many candidate sites were dropped (first-party RSS or bot blocks); remaining surfaces may still degrade if markup or anti-bot posture changes.
- Large surface area (~53 files / ~1.3k LOC) — review by phase cluster rather than file-by-file from the root.

## Review map

1. `lib/html2rss/configs/` (newest phase dirs first: regulators/agencies → think tanks → Asia/ME/science → IGO/finance → AI/cyber) — confirm `directory.topics`, minimal selectors, `enhance: false` where needed, canonical `channel.url`.
2. `spec/support/botasaurus_fetch_configs.rb` — only Botasaurus-true configs should be listed.
3. `.agents/skills/html2rss-config/SKILL.md` + `scripts/` — workflow docs and helpers; optional for config-only reviewers, but call out if you want agent tooling in a separate PR.

## Validation

- `make validate` — ~101 configs green (last phase)
- `make test` — ~1030 examples green (last phase)
- Focused fetch lane for Botasaurus-backed configs with `BOTASAURUS_SCRAPER_URL=http://localhost:4010`
- Session notes: many candidates dropped for first-party RSS or bot blocks; Faraday vs Botasaurus triage applied per config