### PR TITLE
feat(configs): add Africa newsroom and primary-source feeds

### DIFF
--- a/.agents/skills/html2rss-config/SKILL.md
+++ b/.agents/skills/html2rss-config/SKILL.md
@@ -2,15 +2,16 @@
 name: html2rss-config
 description: >-
   Create or repair curated html2rss YAML feed configs in this repo (lib/html2rss/configs/),
-  including directory.topics, selectors, Faraday vs Botasaurus triage, and the AGENTS.md
-  quality gate. Use when adding a new feed config, fixing a broken/zero-item config,
-  tightening selectors, or diagnosing fetch failures for a curated config. Do not use for
-  html2rss gem core, html2rss-web, docs-only work, or bulk coverage-expansion campaigns.
+  including directory.topics, selectors, Faraday vs Botasaurus triage, RSS probe-before-write,
+  and the AGENTS.md quality gate. Use when adding a new feed config, fixing a broken/zero-item
+  config, tightening selectors, diagnosing fetch failures, or shipping a user-requested batch
+  of configs (still one quality loop each). Do not use for html2rss gem core, html2rss-web,
+  or docs-only work.
 ---
 
 # html2rss-config
 
-Thin workflow skill for **one config at a time**. Quality-gate SSOT: repo root [`AGENTS.md`](../../../AGENTS.md). Do not duplicate that gate here.
+Thin workflow skill for **one config quality loop at a time** (a multi-config PR is OK only when the user asks). Quality-gate SSOT: repo root [`AGENTS.md`](../../../AGENTS.md). Do not duplicate that gate here. Campaign traps: [reference/pitfalls.md](reference/pitfalls.md).
 
 ## Modes
 
@@ -24,15 +25,15 @@ Pick mode from the user ask. Grow later with more modes/references; keep this fi
 ## Before any write
 
 1. Read [`AGENTS.md`](../../../AGENTS.md) (surface selection, selectors, drop rules).
-2. Confirm canonical URL (`curl -I -L`); prefer **registrable-domain** folder.
+2. Confirm canonical URL (`curl -I -L`); prefer **registrable-domain** folder. Watch for HTTPS→HTTP downgrades (Faraday will refuse).
 3. Assign `directory.topics` (1–2) — see [reference/topics.md](reference/topics.md).
-4. If a solid first-party RSS already covers the surface and curated value is low → **drop/defer** with evidence (AGENTS.md). Use `scripts/probe_rss` for a quick check.
+4. Probe **that exact surface** with `scripts/probe_rss`. Exit `3` = first-party feed → drop/defer unless curated value is clearly higher. See [pitfalls.md](reference/pitfalls.md).
 
 ## Tool order
 
 1. **user-html2rss MCP** — `capture_config` / `scrape_url` / `inspect_url` / `validate_config` when discovery works.
 2. Else **core CLI** from PATH or sibling `../html2rss` — `scripts/check_config` resolves this (or raw `html2rss` / `bundle exec exe/html2rss`).
-3. **Botasaurus** when Faraday returns zero items: `BOTASAURUS_SCRAPER_URL=http://localhost:4010`.
+3. **Botasaurus** when Faraday returns zero items or scheme/redirect blocks Faraday: `BOTASAURUS_SCRAPER_URL=http://localhost:4010` (health: `/health`). `wait_timeout_seconds` **≤ 20**.
 4. **Chrome MCP** only if Faraday + Botasaurus fail or the item boundary is unclear. Report Chrome outage in handoff if unavailable.
 
 If MCP discovery fails or the MCP process lacks `BOTASAURUS_SCRAPER_URL`, **skip MCP** and go straight to the CLI — do not burn the timebox retrying discovery.
@@ -41,7 +42,7 @@ If MCP discovery fails or the MCP process lacks `BOTASAURUS_SCRAPER_URL`, **skip
 
 Soft budget: one tight loop per site (~3–4 minutes of wall effort). Faraday → Botasaurus → Chrome. If still zero/noisy → **stop**, report drop/defer with evidence, unless the user says keep going.
 
-Minimal selectors first: `items`, `title`, `url`. Omit brittle optional fields. Set `enhance: false` when chrome leaks in.
+Minimal selectors first: `items`, `title`, `url`. Omit brittle optional fields. Set `enhance: false` when chrome leaks in. Prefer nested title / `aria-label` over whole-card text.
 
 ## Scripts
 

--- a/.agents/skills/html2rss-config/reference/new.md
+++ b/.agents/skills/html2rss-config/reference/new.md
@@ -4,11 +4,11 @@ Add one curated config. SSOT details: [AGENTS.md](../../../../AGENTS.md).
 
 ## Steps
 
-1. Confirm no useful first-party RSS for this surface (else drop/defer). Use `scripts/probe_rss` (HTML `rel=alternate` first, then path guesses). Exit `3` = feed found.
-2. Pick the cleanest list URL (newsroom / archive / category — not marketing homepage).
-3. Capture items via skill tool order (MCP → CLI → Botasaurus → Chrome).
+1. Pick the cleanest list URL (newsroom / archive / category — not marketing homepage). Confirm with `curl -I -L` (canonical host; no HTTPS→HTTP downgrade unless you plan Botasaurus).
+2. Confirm no useful first-party RSS **for that exact URL** (else drop/defer). Use `scripts/probe_rss`. Exit `3` = feed found.
+3. Capture items via skill tool order (MCP → CLI → Botasaurus → Chrome). If `auto` is empty, still inspect HTML before assuming JS-only — see [pitfalls.md](pitfalls.md).
 4. Write YAML under `lib/html2rss/configs/<registrable-domain>/<name>.yml`.
-5. Run `scripts/check_config …` (and `--fetch` / `--botasaurus` as needed); `scripts/register_botasaurus` if Botasaurus-backed.
+5. Run `scripts/check_config …` (and `--fetch` / `--botasaurus` as needed); verify real `<item>` rows, not only the summary. `scripts/register_botasaurus` if Botasaurus-backed.
 6. Handoff per skill.
 
 ## YAML skeleton
@@ -37,8 +37,8 @@ selectors:
 Notes:
 
 - Always include `directory.topics` (1–2) — see [topics.md](topics.md).
-- Set `channel.language` when clear (`en` / `de` / `es` / …).
-- Add `strategy: botasaurus` + request wait selectors only when Faraday cannot produce items.
+- Set `channel.language` when clear (`en` / `de` / `es` / …). Prefer a real region `time_zone` when obvious (`Africa/Johannesburg`, `Africa/Cairo`, …).
+- Add `strategy: botasaurus` only when Faraday cannot produce items (or Faraday is blocked by scheme/redirect). Keep `wait_timeout_seconds` **≤ 20**.
 - Parameterized URLs need a `parameters:` block with `type: string` and `default`.
 - Prefer item-local selectors; anchor on article URL path fragments when possible.
 
@@ -46,9 +46,12 @@ Notes:
 
 Live `feed` shows repeated real articles, no nav/footer leakage, absolute URLs. Then repo `make validate` + `make test` + focused fetch.
 
-Footnotes from campaign experience:
+## Footnotes
+
+See [pitfalls.md](pitfalls.md) for full campaign traps. Short list:
 
 - **Folder name:** registrable domain only — avoid `www.` folders unless the host is uniquely `www`.
-- **Archive size:** if the list HTML embeds a full multi-year archive (hundreds–thousands of items), prefer a `/latest` or paginated surface; otherwise note the blast radius in handoff.
-- **Paywall:** titles that work while bodies are gated are shippable; mention premium/paywall risk in handoff.
-- **MCP:** if `user-html2rss` discovery is errored or missing `BOTASAURUS_SCRAPER_URL`, skip MCP and use the CLI path immediately.
+- **Archive size:** if the list HTML embeds a full multi-year archive, prefer `/latest` or paginated; note blast radius in handoff.
+- **Paywall:** titles OK while bodies gated are shippable; mention risk in handoff.
+- **MCP:** errored discovery or missing Botasaurus env → skip MCP, use CLI immediately.
+- **Batch PR:** allowed when the user asks; still one probe→feed→fetch loop per config.

--- a/.agents/skills/html2rss-config/reference/pitfalls.md
+++ b/.agents/skills/html2rss-config/reference/pitfalls.md
@@ -1,0 +1,61 @@
+# Runtime pitfalls (campaign harvest)
+
+Hard-won notes for `new` / `repair`. Prefer these over rediscovering the same traps.
+SSOT for quality gate remains [AGENTS.md](../../../../AGENTS.md).
+
+## Probe the exact surface
+
+- Run `scripts/probe_rss` on the **same URL** you will put in `channel.url`, not only the domain homepage.
+- Example: AllAfrica homepage looked RSS-free; `https://allafrica.com/latest/` advertises a working RDF/RSS → **defer**.
+- Exit `3` = feed found → drop/defer unless curated value is clearly higher than the native feed.
+
+## Coverage / gap campaigns (when the user asks)
+
+Still **one config quality loop at a time**. A single PR with many configs is fine if the user asked for it — do not skip probe → selectors → `check_config` → focused fetch per file.
+
+Prefer additions that:
+
+- lack usable first-party RSS
+- are primary sources (IGO / regulator / think tank / dedicated newsroom list)
+- avoid NA/EU-only shortlists when the ask is “global” or names a region (Africa, LATAM, …)
+
+Defer WordPress/national newsrooms that already ship `/feed` or `rel=alternate`.
+
+## Faraday vs “JS site”
+
+- `html2rss auto` returning 0 items ≠ empty HTML. **Fetch and inspect** (`curl -L` + Nokogiri, or Botasaurus `/scrape` HTML) before declaring Botasaurus-only.
+- ISS Africa press/ISS Today: Faraday HTML already contained `a.card[href^=…]`; auto failed; explicit selectors shipped on Faraday.
+- Prefer nested title selectors (`h6.card-subtitle`, `aria-label`) over whole-card text (dates, bylines, “PRIME”, region chrome).
+
+## Redirects and schemes
+
+- Faraday **rejects HTTPS→HTTP downgrades** (`UnsupportedUrlScheme`). Confirm with `curl -I -L` and watch `Location`.
+- If the only stable surface downgrades: try Botasaurus once; if still flaky/timeout → **drop**, do not ship a lottery config (tralac lesson).
+
+## Botasaurus contract
+
+- Health: `GET http://localhost:4010/health` (root `/` is often 404 — that is normal).
+- Env: `BOTASAURUS_SCRAPER_URL=http://localhost:4010`.
+- **`wait_timeout_seconds` must be ≤ 20** (API validation). Values like 30/45 → HTTP **422**.
+- 504 / scrape timeout → remove brittle `wait_for_selector`, retry once, then drop if still unreliable.
+- Shipping `strategy: botasaurus` → always `scripts/register_botasaurus domain/file.yml`.
+
+## Reading `check_config` output
+
+- The script may print the **channel title** in the first summary lines. Confirm item quality by inspecting RSS `<item>` rows (or Nokogiri on feed XML), not the summary alone.
+
+## Tool order reminders
+
+- If `user-html2rss` MCP is `error` / discovery failed → **skip immediately** to CLI. Do not burn the timebox.
+- Chrome MCP is last resort; curl + Botasaurus HTML + explicit selectors often enough. Report Chrome availability in handoff.
+
+## Selector patterns that worked
+
+| Pattern | Example |
+| -------- | ------- |
+| Drupal field link | `span.field-content a[href^="/latest-news/"]` (SADC) |
+| Card anchor + nested title | `a.card[href^="/iss-today/"]` + `h6.card-subtitle` (ISS) |
+| Heading link | `h4.title a[href*="/News/"]` (Ahram); `h4 a[href*="lang2.html"]` (PanaPress) |
+| Clean `aria-label` | `a[href*="/tea/news/"][aria-label]` + `extractor: attribute` / `attribute: aria-label` (EastAfrican) |
+
+Always set `enhance: false` on items unless you have proven need.

--- a/.agents/skills/html2rss-config/reference/repair.md
+++ b/.agents/skills/html2rss-config/reference/repair.md
@@ -11,6 +11,7 @@ Fix one existing config. SSOT: [AGENTS.md](../../../../AGENTS.md). Runtime Debug
    - If Botasaurus works → keep config narrow; set `strategy: botasaurus`; run `scripts/register_botasaurus`.
 4. If both request strategies fail or items are wrong → Chrome MCP snapshot; confirm item boundary / final URL after redirects.
 5. Compare core `feed` vs configs-repo focused fetch when they disagree (request-strategy mismatch, not “selectors OK”). Agency/CDN sites often treat the gem UA differently than a browser — expect intermittent 403/504 in the fetch lane even when CLI `feed` looked fine; prefer Botasaurus or drop.
+6. Botasaurus **422** with `wait_timeout_seconds` → value must be ≤ 20 (see [pitfalls.md](pitfalls.md)). **504** → drop wait selector or drop the config.
 
 ## Fix order
 

--- a/lib/html2rss/configs/ahram.org.eg/egypt.yml
+++ b/lib/html2rss/configs/ahram.org.eg/egypt.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+channel:
+  url: https://english.ahram.org.eg/Portal/1/Egypt.aspx
+  language: en
+  time_zone: Africa/Cairo
+  ttl: 360
+selectors:
+  items:
+    selector: 'h4.title a[href*="/News/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/issafrica.org/iss-today.yml
+++ b/lib/html2rss/configs/issafrica.org/iss-today.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - research
+channel:
+  url: https://issafrica.org/iss-today
+  language: en
+  time_zone: Africa/Johannesburg
+  ttl: 360
+selectors:
+  items:
+    selector: 'a.card[href^="/iss-today/"]'
+    enhance: false
+  title:
+    selector: h6.card-subtitle
+  url:
+    extractor: href

--- a/lib/html2rss/configs/issafrica.org/press-releases.yml
+++ b/lib/html2rss/configs/issafrica.org/press-releases.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - research
+channel:
+  url: https://issafrica.org/about-us/press-releases
+  language: en
+  time_zone: Africa/Johannesburg
+  ttl: 720
+selectors:
+  items:
+    selector: 'a.card[href^="/about-us/press-releases/"]'
+    enhance: false
+  title:
+    selector: h6.card-subtitle
+  url:
+    extractor: href

--- a/lib/html2rss/configs/panapress.com/latest.yml
+++ b/lib/html2rss/configs/panapress.com/latest.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+strategy: botasaurus
+
+channel:
+  url: https://www.panapress.com/
+  language: en
+  time_zone: UTC
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'h4 a[href*="lang2.html"]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'h4 a[href*="lang2.html"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/sadc.int/latest-news.yml
+++ b/lib/html2rss/configs/sadc.int/latest-news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - news
+channel:
+  url: https://www.sadc.int/latest-news
+  language: en
+  time_zone: UTC
+  ttl: 360
+selectors:
+  items:
+    selector: 'span.field-content a[href^="/latest-news/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/theeastafrican.co.ke/news.yml
+++ b/lib/html2rss/configs/theeastafrican.co.ke/news.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+strategy: botasaurus
+
+channel:
+  url: https://www.theeastafrican.co.ke/tea/news
+  language: en
+  time_zone: Africa/Nairobi
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'a[href*="/tea/news/"][aria-label]'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'a[href*="/tea/news/"][aria-label]'
+    enhance: false
+  title:
+    extractor: attribute
+    attribute: aria-label
+  url:
+    extractor: href

--- a/spec/support/botasaurus_fetch_configs.rb
+++ b/spec/support/botasaurus_fetch_configs.rb
@@ -16,8 +16,10 @@ module BotasaurusFetchConfigs
     occrp.org/news.yml
     oecd.org/newsroom.yml
     opec.org/press-releases.yml
+    panapress.com/latest.yml
     stackoverflow.com/hot_network_questions.yml
     support.apple.com/en_gb_ht201222.yml
+    theeastafrican.co.ke/news.yml
     thoughtworks.com/insights.yml
     who.int/news.yml
     worldbank.org/news.yml


### PR DESCRIPTION
## What changed

- Add Faraday configs: `sadc.int/latest-news`, `issafrica.org/iss-today`, `issafrica.org/press-releases`, `ahram.org.eg/egypt`
- Add Botasaurus configs: `panapress.com/latest`, `theeastafrican.co.ke/news` (registered in `spec/support/botasaurus_fetch_configs.rb`)

## Why

The curated catalog had **zero** Africa domains. This batch prefers no/weak first-party RSS surfaces across Southern, East, North, and pan-African sources.

## Deferred / dropped

- **Deferred (native RSS):** AU, EAC, ITWeb Africa, AllAfrica RDF, AfDB, ECOWAS, PAP, many national newsrooms
- **Dropped:** tralac (HTTPS→HTTP + Botasaurus timeouts), news24 (blocked), Jeune Afrique (redirect loops), UNECA/Stats SA (TLS/bot failures)

## Risk

- PanaPress / EastAfrican depend on Botasaurus; selector drift and bot challenges possible
- ISS Africa card markup is stable today but JS-heavy pages could regress to empty Faraday HTML
- Low for Faraday SADC / Ahram / ISS paths

## Test plan

- [x] `scripts/check_config` + focused `--fetch` for Faraday configs
- [x] `scripts/check_config … --fetch --botasaurus` for PanaPress + EastAfrican (`BOTASAURUS_SCRAPER_URL=http://localhost:4010`)
- [x] `make validate` (107 configs)
- [x] `make test` (1090 examples, 0 failures)
- Chrome MCP unavailable this session; DOM inspected via curl / Botasaurus HTML