### PR TITLE
feat(configs): Global South coverage expansion (9 configs)

### DIFF
--- a/.agents/skills/html2rss-config/SKILL.md
+++ b/.agents/skills/html2rss-config/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 
 # html2rss-config
 
-Thin workflow skill for **one config quality loop at a time** (a multi-config PR is OK only when the user asks). Quality-gate SSOT: repo root [`AGENTS.md`](../../../AGENTS.md). Do not duplicate that gate here. Campaign traps: [reference/pitfalls.md](reference/pitfalls.md).
+Thin workflow skill for **one config quality loop at a time** (a multi-config PR is OK only when the user asks). Quality-gate SSOT: repo root [`AGENTS.md`](../../../AGENTS.md). Do not duplicate that gate here. Campaign traps: [reference/pitfalls.md](reference/pitfalls.md). Batch pipeline (N=1 and N>1): [reference/batch.md](reference/batch.md).
 
 ## Modes
 
@@ -48,11 +48,11 @@ Minimal selectors first: `items`, `title`, `url`. Omit brittle optional fields. 
 
 Run from repo root. Prefer these over ad‑hoc CLI glue:
 
-| Script                                                       | Purpose                                                                     |
-| ------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| Script                                                       | Purpose                                                                                                                                                                 |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`scripts/probe_rss`](scripts/probe_rss)                     | First-party RSS probe (HTML `rel=alternate` then path guesses). Exit `0` = none; `3` = found (consider drop). Under `set -e`, check `$?` — do not treat `3` as failure. |
-| [`scripts/check_config`](scripts/check_config)               | `validate` + `feed` (fail on 0 items); optional `--fetch` / `--botasaurus`. Resolves CLI via PATH or sibling `../html2rss`. |
-| [`scripts/register_botasaurus`](scripts/register_botasaurus) | Idempotent sorted add to `spec/support/botasaurus_fetch_configs.rb`.        |
+| [`scripts/check_config`](scripts/check_config)               | `validate` + `feed` (fail on 0 items); optional `--fetch` / `--botasaurus`. Resolves CLI via PATH or sibling `../html2rss`.                                             |
+| [`scripts/register_botasaurus`](scripts/register_botasaurus) | Idempotent sorted add to `spec/support/botasaurus_fetch_configs.rb`.                                                                                                    |
 
 Examples:
 

--- a/.agents/skills/html2rss-config/reference/batch.md
+++ b/.agents/skills/html2rss-config/reference/batch.md
@@ -1,0 +1,92 @@
+# Batch pipeline
+
+Default workflow for **N=1** and **N>1**. Pass a one-URL list for a single add — same scripts and phases.
+
+Quality-gate SSOT: [AGENTS.md](../../../../AGENTS.md). Wall-time constraints: [pitfalls.md](pitfalls.md).
+
+## Prerequisites
+
+- Repo root as cwd.
+- Sibling `../html2rss` or `html2rss` on `PATH` for validate/feed.
+- Optional: `BOTASAURUS_SCRAPER_URL=http://localhost:4010` when Faraday cannot fetch items.
+- Ruby with stdlib + Nokogiri (Gemfile / system gem used by this repo).
+
+## Phase 0 — parallel recon
+
+```bash
+.agents/skills/html2rss-config/scripts/batch_recon \
+  --cache-dir tmp/html2rss-recon \
+  'https://example.com/news/'
+
+.agents/skills/html2rss-config/scripts/batch_recon \
+  --cache-dir tmp/html2rss-recon \
+  --file candidates.tsv
+```
+
+`candidates.tsv` lines: `URL`, or `slug\tURL`, or `slug\tregion\tURL` (`#` comments ok).
+
+**Success:** `tmp/html2rss-recon/ledger.tsv` with `BUILD` / `DEFER` / `DROP`, plus one `.html` cache file per slug.
+
+Verdicts:
+
+| Verdict | Meaning                                                                                             |
+| ------- | --------------------------------------------------------------------------------------------------- |
+| `BUILD` | No verified first-party feed; HTML cached for selectors (may still need Botasaurus if thin/blocked) |
+| `DEFER` | Native RSS/Atom verified on the surface                                                             |
+| `DROP`  | Unreachable, HTTP error, HTTPS→HTTP downgrade, or error page                                        |
+
+Dry plan (no network): `batch_recon --dry-run --file candidates.tsv`
+
+## Phase 1 — selectors from cache
+
+```bash
+.agents/skills/html2rss-config/scripts/analyze_html \
+  --from-ledger tmp/html2rss-recon/ledger.tsv
+```
+
+Write YAMLs only for `BUILD` rows under `lib/html2rss/configs/<registrable-domain>/`. Use MCP/`check_config` only when cache analysis is insufficient. Botasaurus scrape: thin/empty/blocked HTML only — one retry max (`wait_timeout_seconds` ≤ 20), then drop.
+
+YAML notes: [new.md](new.md). Topics: [topics.md](topics.md).
+
+## Phase 2 — batched verification
+
+```bash
+# offline validate (example: sibling CLI)
+html2rss validate lib/html2rss/configs/domain/*.yml
+
+# parallel feed checks (Faraday group)
+.agents/skills/html2rss-config/scripts/check_config domain/a.yml &
+.agents/skills/html2rss-config/scripts/check_config domain/b.yml &
+wait
+
+# one rspec boot per fetch lane
+bundle exec rspec --tag fetch \
+  --example 'domain/a.yml' \
+  --example 'domain/b.yml' \
+  spec/html2rss/configs_dynamic_spec.rb
+```
+
+## Phase 3 — campaign gate
+
+```bash
+make validate
+make test
+.agents/skills/html2rss-config/scripts/register_botasaurus domain/bot.yml   # if needed
+```
+
+## N=1 shortcut
+
+Same pipeline; one URL:
+
+```bash
+.agents/skills/html2rss-config/scripts/batch_recon \
+  --cache-dir tmp/html2rss-recon \
+  'https://example.com/news/'
+.agents/skills/html2rss-config/scripts/analyze_html \
+  --from-ledger tmp/html2rss-recon/ledger.tsv
+# write YAML → check_config → focused fetch → make validate/test when done
+```
+
+## Repair campaigns
+
+For broken configs, treat paths as the candidate list: diagnose with `check_config`, then the same Faraday→Botasaurus→drop loop. See [repair.md](repair.md).

--- a/.agents/skills/html2rss-config/reference/pitfalls.md
+++ b/.agents/skills/html2rss-config/reference/pitfalls.md
@@ -1,13 +1,58 @@
+# Batch wall-time constraints
+
+Present constraints for config campaigns (N≥1). Quality-gate commands stay in [AGENTS.md](../../../../AGENTS.md).
+
+## Recon
+
+- Probe the **exact** intended `channel.url` (not a homepage stand-in).
+- Prefer `scripts/batch_recon` over sequential `scripts/probe_rss` loops.
+- Cache HTML once per candidate; author selectors from that cache.
+- Treat first-party RSS on the surface as **DEFER** (no curated config unless curated value is explicit).
+- Use `html2rss auto` only as optional discovery; never as proof a config is ready (AGENTS.md Auto-Source).
+
+## Request strategy
+
+- Faraday first.
+- Botasaurus only when Faraday returns zero/blocked items and the browser shows a real list.
+- Cap Botasaurus `wait_timeout_seconds` at **≤ 20**.
+- One scrape retry on transient Botasaurus errors, then **DROP** with ledger evidence — no retry spirals.
+
+## Authoring
+
+- Soft budget ~3–4 minutes wall effort per BUILD site after recon.
+- Minimal selectors first: `items`, `title`, `url`. Drop brittle optionals early.
+- Set `enhance: false` when enhancement pulls chrome/nav/hero.
+
+## Verification batching
+
+- Offline: validate all new/changed YAML files in one pass.
+- Feed checks: run several `scripts/check_config` jobs in parallel (grouped by strategy).
+- Focused fetch: **one rspec boot per lane**, multiple `--example` flags:
+
+```bash
+bundle exec rspec --tag fetch \
+  --example 'domain/a.yml' \
+  --example 'domain/b.yml' \
+  spec/html2rss/configs_dynamic_spec.rb
+```
+
+Botasaurus lane: same command with `BOTASAURUS_SCRAPER_URL=http://localhost:4010`.
+
+- For campaigns: `make validate` and `make test` **once at the end**, not per config.
+- Register every shipped Botasaurus config with `scripts/register_botasaurus`.
+
+---
+
 # Runtime pitfalls (campaign harvest)
 
 Hard-won notes for `new` / `repair`. Prefer these over rediscovering the same traps.
-SSOT for quality gate remains [AGENTS.md](../../../../AGENTS.md).
+SSOT for quality gate remains [AGENTS.md](../../../../AGENTS.md). Pipeline: [batch.md](batch.md).
 
 ## Probe the exact surface
 
-- Run `scripts/probe_rss` on the **same URL** you will put in `channel.url`, not only the domain homepage.
+- Run `scripts/probe_rss` / `scripts/batch_recon` on the **same URL** you will put in `channel.url`, not only the domain homepage.
 - Example: AllAfrica homepage looked RSS-free; `https://allafrica.com/latest/` advertises a working RDF/RSS → **defer**.
-- Exit `3` = feed found → drop/defer unless curated value is clearly higher than the native feed.
+- Exit `3` / ledger `DEFER` = feed found → drop/defer unless curated value is clearly higher than the native feed.
 
 ## Coverage / gap campaigns (when the user asks)
 

--- a/.agents/skills/html2rss-config/scripts/analyze_html
+++ b/.agents/skills/html2rss-config/scripts/analyze_html
@@ -1,0 +1,210 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Batch Nokogiri selector hints over cached HTML files (no network).
+# Prefer repeated article-like anchors, heading links, and common card selectors.
+#
+# Usage (from repo root):
+#   .agents/skills/html2rss-config/scripts/analyze_html tmp/html2rss-recon/example.com.html
+#   .agents/skills/html2rss-config/scripts/analyze_html --base https://example.com/news/ file.html
+#   .agents/skills/html2rss-config/scripts/analyze_html --from-ledger tmp/html2rss-recon/ledger.tsv
+#   .agents/skills/html2rss-config/scripts/analyze_html --from-ledger ledger.tsv --verdict BUILD
+#
+# Options:
+#   --base URL           Base URL for relative hrefs (single-file / override)
+#   --from-ledger PATH   Read html_path (+ canonical_url) from batch_recon ledger
+#   --verdict NAME       Filter ledger rows (default with --from-ledger: BUILD)
+#   --min-repeat N       Minimum repeated path count to print (default: 3)
+#   -h, --help
+
+require 'nokogiri'
+require 'uri'
+
+NEWSISH = %r{(news|press|noticia|actualit|release|communiqu|artikel|article|berita|post|media|event|speech|relcontent|AllRel|/pr/)}i
+CARD_SELECTORS = %w[article .card .views-row .post .news-item .press-release li.media].freeze
+
+def usage!(msg = nil)
+  warn(msg) if msg
+  warn(<<~USAGE)
+    Usage: analyze_html [options] HTML_FILE [HTML_FILE ...]
+           analyze_html [options] --from-ledger ledger.tsv
+
+    Options:
+      --base URL           Base URL for resolving relative hrefs
+      --from-ledger PATH   Use batch_recon ledger (html_path + canonical_url)
+      --verdict NAME       Ledger verdict filter (default: BUILD)
+      --min-repeat N       Min path repeats to show (default: 3)
+      -h, --help
+  USAGE
+  exit 1
+end
+
+def parse_args(argv)
+  opts = {
+    base: nil,
+    ledger: nil,
+    verdict: 'BUILD',
+    min_repeat: 3,
+    files: [],
+    verdict_explicit: false
+  }
+  i = 0
+  while i < argv.size
+    case argv[i]
+    when '-h', '--help' then usage!
+    when '--base'
+      usage!('Missing value for --base') unless argv[i + 1]
+      opts[:base] = argv[i += 1]
+    when '--from-ledger'
+      usage!('Missing value for --from-ledger') unless argv[i + 1]
+      opts[:ledger] = argv[i += 1]
+    when '--verdict'
+      usage!('Missing value for --verdict') unless argv[i + 1]
+      opts[:verdict] = argv[i += 1]
+      opts[:verdict_explicit] = true
+    when '--min-repeat'
+      usage!('Missing value for --min-repeat') unless argv[i + 1]
+      opts[:min_repeat] = Integer(argv[i += 1])
+    when /^--/
+      usage!("Unknown option: #{argv[i]}")
+    else
+      opts[:files] << argv[i]
+    end
+    i += 1
+  end
+  opts
+end
+
+def parent_sig(node)
+  parts = []
+  cur = node
+  4.times do
+    break unless cur&.element?
+
+    cls = cur['class'].to_s.split.grep_v(/^(js-|is-|active|hidden)/).first(2).join('.')
+    parts << [cur.name, cls].reject(&:empty?).join('.')
+    cur = cur.parent
+  end
+  parts.join(' < ')
+end
+
+def normalize_path_key(path)
+  path.to_s
+      .gsub(%r{/\d{4}/\d{2}/}, '/YYYY/MM/')
+      .gsub(%r{/\d+}, '/N')
+      .gsub(/-[0-9a-f]{8,}/, '-HASH')
+end
+
+def load_targets(opts)
+  if opts[:ledger]
+    usage!("Ledger not found: #{opts[:ledger]}") unless File.file?(opts[:ledger])
+    lines = File.readlines(opts[:ledger], chomp: true)
+    usage!('Empty ledger') if lines.empty?
+
+    header = lines.shift.split("\t")
+    idx = header.each_with_index.to_h
+    %w[slug verdict canonical_url html_path].each do |col|
+      usage!("Ledger missing column: #{col}") unless idx[col]
+    end
+
+    filter = opts[:verdict]
+    filter = nil if filter.to_s.casecmp('ALL').zero?
+
+    return lines.filter_map do |line|
+      cols = line.split("\t")
+      next if filter && cols[idx['verdict']] != filter
+
+      {
+        slug: cols[idx['slug']],
+        path: cols[idx['html_path']],
+        base: opts[:base] || cols[idx['canonical_url']]
+      }
+    end
+  end
+
+  usage!('Pass HTML files and/or --from-ledger') if opts[:files].empty?
+  opts[:files].map do |path|
+    {
+      slug: File.basename(path, '.*'),
+      path: path,
+      base: opts[:base] || "https://#{File.basename(path, '.*')}/"
+    }
+  end
+end
+
+def analyze(slug:, path:, base:, min_repeat:)
+  unless File.file?(path)
+    puts '=' * 72
+    puts "#{slug} MISSING #{path}"
+    return
+  end
+
+  raw = File.read(path)
+  puts '=' * 72
+  puts "#{slug} bytes=#{raw.bytesize} base=#{base} path=#{path}"
+  if raw.bytesize < 800
+    puts '  THIN/EMPTY — Botasaurus candidate (or DROP if still empty after one scrape)'
+    return
+  end
+
+  doc = Nokogiri::HTML(raw)
+  anchors = doc.css('a[href]').reject { |a| a['href'].to_s.start_with?('#', 'javascript:', 'mailto:') }
+  puts "  anchors=#{anchors.size}"
+
+  buckets = Hash.new { |h, k| h[k] = [] }
+  anchors.each do |a|
+    href = a['href'].to_s
+    text = a.text.gsub(/\s+/, ' ').strip
+    title = text.empty? ? a['aria-label'].to_s.strip : text
+    next if title.length < 12
+
+    path_key = begin
+      normalize_path_key(URI.join(base, href).path)
+    rescue StandardError
+      normalize_path_key(href)
+    end
+    buckets[path_key] << {
+      href: href,
+      title: title[0, 90],
+      parent: parent_sig(a),
+      classes: a['class'].to_s
+    }
+  end
+
+  ranked = buckets.sort_by { |k, v| [-v.size, NEWSISH.match?(k) ? 0 : 1, k] }
+  ranked.first(8).each do |path_key, items|
+    next if items.size < min_repeat
+
+    sample = items.first(3)
+    puts "  PATH x#{items.size}: #{path_key}"
+    puts "    parent: #{sample.first[:parent]}"
+    puts "    classes: #{sample.map { |i| i[:classes] }.uniq.first(3).inspect}"
+    sample.each { |i| puts "    - #{i[:title].inspect} => #{i[:href][0, 100]}" }
+  end
+
+  %w[h1 h2 h3 h4 h5 h6].each do |h|
+    links = doc.css("#{h} a[href]")
+    next if links.size < min_repeat
+
+    sample = links.first(2).map { |a| a.text.gsub(/\s+/, ' ').strip[0, 60] }
+    puts "  #{h} a x#{links.size}: sample=#{sample}"
+  end
+
+  CARD_SELECTORS.each do |sel|
+    nodes = doc.css(sel)
+    next if nodes.size < min_repeat
+
+    puts "  SEL #{sel} x#{nodes.size}"
+  end
+end
+
+opts = parse_args(ARGV)
+targets = load_targets(opts)
+if targets.empty?
+  warn('No targets matched (check --verdict / files)')
+  exit 0
+end
+
+targets.each do |t|
+  analyze(slug: t[:slug], path: t[:path], base: t[:base], min_repeat: opts[:min_repeat])
+end

--- a/.agents/skills/html2rss-config/scripts/analyze_html
+++ b/.agents/skills/html2rss-config/scripts/analyze_html
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength
+
 # Batch Nokogiri selector hints over cached HTML files (no network).
 # Prefer repeated article-like anchors, heading links, and common card selectors.
 #
@@ -9,38 +11,41 @@
 #   .agents/skills/html2rss-config/scripts/analyze_html --base https://example.com/news/ file.html
 #   .agents/skills/html2rss-config/scripts/analyze_html --from-ledger tmp/html2rss-recon/ledger.tsv
 #   .agents/skills/html2rss-config/scripts/analyze_html --from-ledger ledger.tsv --verdict BUILD
-#
-# Options:
-#   --base URL           Base URL for relative hrefs (single-file / override)
-#   --from-ledger PATH   Read html_path (+ canonical_url) from batch_recon ledger
-#   --verdict NAME       Filter ledger rows (default with --from-ledger: BUILD)
-#   --min-repeat N       Minimum repeated path count to print (default: 3)
-#   -h, --help
 
 require 'nokogiri'
 require 'uri'
 
-NEWSISH = %r{(news|press|noticia|actualit|release|communiqu|artikel|article|berita|post|media|event|speech|relcontent|AllRel|/pr/)}i
+NEWSISH = %r{
+  (news|press|noticia|actualit|release|communiqu|artikel|article|
+   berita|post|media|event|speech|relcontent|AllRel|/pr/)
+}ix
 CARD_SELECTORS = %w[article .card .views-row .post .news-item .press-release li.media].freeze
+USAGE = <<~USAGE
+  Usage: analyze_html [options] HTML_FILE [HTML_FILE ...]
+         analyze_html [options] --from-ledger ledger.tsv
+
+  Options:
+    --base URL           Base URL for resolving relative hrefs
+    --from-ledger PATH   Use batch_recon ledger (html_path + canonical_url)
+    --verdict NAME       Ledger verdict filter (default: BUILD)
+    --min-repeat N       Min path repeats to show (default: 3)
+    -h, --help
+USAGE
 
 def usage!(msg = nil)
   warn(msg) if msg
-  warn(<<~USAGE)
-    Usage: analyze_html [options] HTML_FILE [HTML_FILE ...]
-           analyze_html [options] --from-ledger ledger.tsv
-
-    Options:
-      --base URL           Base URL for resolving relative hrefs
-      --from-ledger PATH   Use batch_recon ledger (html_path + canonical_url)
-      --verdict NAME       Ledger verdict filter (default: BUILD)
-      --min-repeat N       Min path repeats to show (default: 3)
-      -h, --help
-  USAGE
+  warn(USAGE)
   exit 1
 end
 
-def parse_args(argv)
-  opts = {
+def take_arg!(argv, index, flag)
+  usage!("Missing value for #{flag}") unless argv[index + 1]
+
+  argv[index + 1]
+end
+
+def default_opts
+  {
     base: nil,
     ledger: nil,
     verdict: 'BUILD',
@@ -48,29 +53,38 @@ def parse_args(argv)
     files: [],
     verdict_explicit: false
   }
-  i = 0
-  while i < argv.size
-    case argv[i]
-    when '-h', '--help' then usage!
-    when '--base'
-      usage!('Missing value for --base') unless argv[i + 1]
-      opts[:base] = argv[i += 1]
-    when '--from-ledger'
-      usage!('Missing value for --from-ledger') unless argv[i + 1]
-      opts[:ledger] = argv[i += 1]
-    when '--verdict'
-      usage!('Missing value for --verdict') unless argv[i + 1]
-      opts[:verdict] = argv[i += 1]
-      opts[:verdict_explicit] = true
-    when '--min-repeat'
-      usage!('Missing value for --min-repeat') unless argv[i + 1]
-      opts[:min_repeat] = Integer(argv[i += 1])
-    when /^--/
-      usage!("Unknown option: #{argv[i]}")
-    else
-      opts[:files] << argv[i]
-    end
-    i += 1
+end
+
+def apply_flag(opts, argv, index)
+  case argv[index]
+  when '-h', '--help' then usage!
+  when '--base'
+    opts[:base] = take_arg!(argv, index, '--base')
+    index + 1
+  when '--from-ledger'
+    opts[:ledger] = take_arg!(argv, index, '--from-ledger')
+    index + 1
+  when '--verdict'
+    opts[:verdict] = take_arg!(argv, index, '--verdict')
+    opts[:verdict_explicit] = true
+    index + 1
+  when '--min-repeat'
+    opts[:min_repeat] = Integer(take_arg!(argv, index, '--min-repeat'))
+    index + 1
+  when /^--/
+    usage!("Unknown option: #{argv[index]}")
+  else
+    opts[:files] << argv[index]
+    index
+  end
+end
+
+def parse_args(argv)
+  opts = default_opts
+  index = 0
+  while index < argv.size
+    index = apply_flag(opts, argv, index)
+    index += 1
   end
   opts
 end
@@ -95,34 +109,38 @@ def normalize_path_key(path)
       .gsub(/-[0-9a-f]{8,}/, '-HASH')
 end
 
-def load_targets(opts)
-  if opts[:ledger]
-    usage!("Ledger not found: #{opts[:ledger]}") unless File.file?(opts[:ledger])
-    lines = File.readlines(opts[:ledger], chomp: true)
-    usage!('Empty ledger') if lines.empty?
-
-    header = lines.shift.split("\t")
-    idx = header.each_with_index.to_h
-    %w[slug verdict canonical_url html_path].each do |col|
-      usage!("Ledger missing column: #{col}") unless idx[col]
-    end
-
-    filter = opts[:verdict]
-    filter = nil if filter.to_s.casecmp('ALL').zero?
-
-    return lines.filter_map do |line|
-      cols = line.split("\t")
-      next if filter && cols[idx['verdict']] != filter
-
-      {
-        slug: cols[idx['slug']],
-        path: cols[idx['html_path']],
-        base: opts[:base] || cols[idx['canonical_url']]
-      }
-    end
+def ledger_column_index(header)
+  idx = header.each_with_index.to_h
+  %w[slug verdict canonical_url html_path].each do |col|
+    usage!("Ledger missing column: #{col}") unless idx[col]
   end
+  idx
+end
 
+def targets_from_ledger(opts)
+  usage!("Ledger not found: #{opts[:ledger]}") unless File.file?(opts[:ledger])
+  lines = File.readlines(opts[:ledger], chomp: true)
+  usage!('Empty ledger') if lines.empty?
+
+  idx = ledger_column_index(lines.shift.split("\t"))
+  filter = opts[:verdict]
+  filter = nil if filter.to_s.casecmp('ALL').zero?
+
+  lines.filter_map do |line|
+    cols = line.split("\t")
+    next if filter && cols[idx['verdict']] != filter
+
+    {
+      slug: cols[idx['slug']],
+      path: cols[idx['html_path']],
+      base: opts[:base] || cols[idx['canonical_url']]
+    }
+  end
+end
+
+def targets_from_files(opts)
   usage!('Pass HTML files and/or --from-ledger') if opts[:files].empty?
+
   opts[:files].map do |path|
     {
       slug: File.basename(path, '.*'),
@@ -130,6 +148,76 @@ def load_targets(opts)
       base: opts[:base] || "https://#{File.basename(path, '.*')}/"
     }
   end
+end
+
+def load_targets(opts)
+  return targets_from_ledger(opts) if opts[:ledger]
+
+  targets_from_files(opts)
+end
+
+def anchor_title(anchor)
+  text = anchor.text.gsub(/\s+/, ' ').strip
+  text.empty? ? anchor['aria-label'].to_s.strip : text
+end
+
+def path_key_for(href, base)
+  normalize_path_key(URI.join(base, href).path)
+rescue StandardError
+  normalize_path_key(href)
+end
+
+def bucket_anchors(anchors, base)
+  buckets = Hash.new { |hash, key| hash[key] = [] }
+  anchors.each do |anchor|
+    href = anchor['href'].to_s
+    title = anchor_title(anchor)
+    next if title.length < 12
+
+    buckets[path_key_for(href, base)] << {
+      href: href,
+      title: title[0, 90],
+      parent: parent_sig(anchor),
+      classes: anchor['class'].to_s
+    }
+  end
+  buckets
+end
+
+def print_path_buckets(buckets, min_repeat)
+  ranked = buckets.sort_by { |key, vals| [-vals.size, NEWSISH.match?(key) ? 0 : 1, key] }
+  ranked.first(8).each do |path_key, items|
+    next if items.size < min_repeat
+
+    sample = items.first(3)
+    puts "  PATH x#{items.size}: #{path_key}"
+    puts "    parent: #{sample.first[:parent]}"
+    puts "    classes: #{sample.map { |item| item[:classes] }.uniq.first(3).inspect}"
+    sample.each { |item| puts "    - #{item[:title].inspect} => #{item[:href][0, 100]}" }
+  end
+end
+
+def print_heading_links(doc, min_repeat)
+  %w[h1 h2 h3 h4 h5 h6].each do |heading|
+    links = doc.css("#{heading} a[href]")
+    next if links.size < min_repeat
+
+    sample = links.first(2).map { |anchor| anchor.text.gsub(/\s+/, ' ').strip[0, 60] }
+    puts "  #{heading} a x#{links.size}: sample=#{sample}"
+  end
+end
+
+def print_card_selectors(doc, min_repeat)
+  CARD_SELECTORS.each do |sel|
+    nodes = doc.css(sel)
+    next if nodes.size < min_repeat
+
+    puts "  SEL #{sel} x#{nodes.size}"
+  end
+end
+
+def usable_anchors(doc)
+  doc.css('a[href]').reject { |anchor| anchor['href'].to_s.start_with?('#', 'javascript:', 'mailto:') }
 end
 
 def analyze(slug:, path:, base:, min_repeat:)
@@ -148,54 +236,11 @@ def analyze(slug:, path:, base:, min_repeat:)
   end
 
   doc = Nokogiri::HTML(raw)
-  anchors = doc.css('a[href]').reject { |a| a['href'].to_s.start_with?('#', 'javascript:', 'mailto:') }
+  anchors = usable_anchors(doc)
   puts "  anchors=#{anchors.size}"
-
-  buckets = Hash.new { |h, k| h[k] = [] }
-  anchors.each do |a|
-    href = a['href'].to_s
-    text = a.text.gsub(/\s+/, ' ').strip
-    title = text.empty? ? a['aria-label'].to_s.strip : text
-    next if title.length < 12
-
-    path_key = begin
-      normalize_path_key(URI.join(base, href).path)
-    rescue StandardError
-      normalize_path_key(href)
-    end
-    buckets[path_key] << {
-      href: href,
-      title: title[0, 90],
-      parent: parent_sig(a),
-      classes: a['class'].to_s
-    }
-  end
-
-  ranked = buckets.sort_by { |k, v| [-v.size, NEWSISH.match?(k) ? 0 : 1, k] }
-  ranked.first(8).each do |path_key, items|
-    next if items.size < min_repeat
-
-    sample = items.first(3)
-    puts "  PATH x#{items.size}: #{path_key}"
-    puts "    parent: #{sample.first[:parent]}"
-    puts "    classes: #{sample.map { |i| i[:classes] }.uniq.first(3).inspect}"
-    sample.each { |i| puts "    - #{i[:title].inspect} => #{i[:href][0, 100]}" }
-  end
-
-  %w[h1 h2 h3 h4 h5 h6].each do |h|
-    links = doc.css("#{h} a[href]")
-    next if links.size < min_repeat
-
-    sample = links.first(2).map { |a| a.text.gsub(/\s+/, ' ').strip[0, 60] }
-    puts "  #{h} a x#{links.size}: sample=#{sample}"
-  end
-
-  CARD_SELECTORS.each do |sel|
-    nodes = doc.css(sel)
-    next if nodes.size < min_repeat
-
-    puts "  SEL #{sel} x#{nodes.size}"
-  end
+  print_path_buckets(bucket_anchors(anchors, base), min_repeat)
+  print_heading_links(doc, min_repeat)
+  print_card_selectors(doc, min_repeat)
 end
 
 opts = parse_args(ARGV)
@@ -205,6 +250,13 @@ if targets.empty?
   exit 0
 end
 
-targets.each do |t|
-  analyze(slug: t[:slug], path: t[:path], base: t[:base], min_repeat: opts[:min_repeat])
+targets.each do |target|
+  analyze(
+    slug: target[:slug],
+    path: target[:path],
+    base: target[:base],
+    min_repeat: opts[:min_repeat]
+  )
 end
+
+# rubocop:enable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength

--- a/.agents/skills/html2rss-config/scripts/batch_recon
+++ b/.agents/skills/html2rss-config/scripts/batch_recon
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/ParameterLists,Metrics/PerceivedComplexity
+
 # Parallel recon for one or many candidate URLs.
 # For each candidate: follow redirects, probe first-party RSS on the exact surface,
 # cache HTML once, emit a BUILD/DEFER/DROP ledger (TSV).
@@ -14,12 +16,6 @@
 #   https://example.com/news/
 #   example.com	https://example.com/news/
 #   example.com	LATAM	https://example.com/news/
-#
-# Options:
-#   --cache-dir DIR   HTML + ledger directory (default: tmp/html2rss-recon)
-#   --ledger PATH     Ledger TSV path (default: CACHE_DIR/ledger.tsv)
-#   --file PATH       Read candidates from file
-#   --dry-run         Parse candidates and print plan; no network
 #
 # Exit 0 always after a completed run (including all-DROP). Exit 1 on usage/parse errors.
 
@@ -42,45 +38,65 @@ FEED_PATHS = %w[
   /blog/rss.xml
 ].freeze
 FEED_CT = %w[rss+xml atom+xml application/rss application/atom].freeze
+USAGE = <<~USAGE
+  Usage: batch_recon [options] URL [URL ...]
+         batch_recon [options] --file candidates.tsv
+
+  Options:
+    --cache-dir DIR   Cache + default ledger dir (default: tmp/html2rss-recon)
+    --ledger PATH     Ledger TSV (default: CACHE_DIR/ledger.tsv)
+    --file PATH       Candidate list (URL lines or slug[\\tregion]\\turl)
+    --dry-run         Print candidates only; no network
+    -h, --help        Show this help
+USAGE
+ASSET_EXT = /\.(svg|png|jpg|jpeg|gif|ico|css|js)(\?|$)/i
+FEED_ACCEPT = 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*'
 
 def usage!(msg = nil)
   warn(msg) if msg
-  warn(<<~USAGE)
-    Usage: batch_recon [options] URL [URL ...]
-           batch_recon [options] --file candidates.tsv
-
-    Options:
-      --cache-dir DIR   Cache + default ledger dir (default: tmp/html2rss-recon)
-      --ledger PATH     Ledger TSV (default: CACHE_DIR/ledger.tsv)
-      --file PATH       Candidate list (URL lines or slug[\\tregion]\\turl)
-      --dry-run         Print candidates only; no network
-      -h, --help        Show this help
-  USAGE
+  warn(USAGE)
   exit 1
 end
 
+def take_arg!(argv, index, flag)
+  usage!("Missing value for #{flag}") unless argv[index + 1]
+
+  argv[index + 1]
+end
+
+def default_opts
+  { cache_dir: 'tmp/html2rss-recon', ledger: nil, file: nil, dry_run: false, urls: [] }
+end
+
+def apply_flag(opts, argv, index)
+  case argv[index]
+  when '-h', '--help' then usage!
+  when '--dry-run'
+    opts[:dry_run] = true
+    index
+  when '--cache-dir'
+    opts[:cache_dir] = take_arg!(argv, index, '--cache-dir')
+    index + 1
+  when '--ledger'
+    opts[:ledger] = take_arg!(argv, index, '--ledger')
+    index + 1
+  when '--file'
+    opts[:file] = take_arg!(argv, index, '--file')
+    index + 1
+  when /^--/
+    usage!("Unknown option: #{argv[index]}")
+  else
+    opts[:urls] << argv[index]
+    index
+  end
+end
+
 def parse_args(argv)
-  opts = { cache_dir: 'tmp/html2rss-recon', ledger: nil, file: nil, dry_run: false, urls: [] }
-  i = 0
-  while i < argv.size
-    case argv[i]
-    when '-h', '--help' then usage!
-    when '--dry-run' then opts[:dry_run] = true
-    when '--cache-dir'
-      usage!('Missing value for --cache-dir') unless argv[i + 1]
-      opts[:cache_dir] = argv[i += 1]
-    when '--ledger'
-      usage!('Missing value for --ledger') unless argv[i + 1]
-      opts[:ledger] = argv[i += 1]
-    when '--file'
-      usage!('Missing value for --file') unless argv[i + 1]
-      opts[:file] = argv[i += 1]
-    when /^--/
-      usage!("Unknown option: #{argv[i]}")
-    else
-      opts[:urls] << argv[i]
-    end
-    i += 1
+  opts = default_opts
+  index = 0
+  while index < argv.size
+    index = apply_flag(opts, argv, index)
+    index += 1
   end
   opts[:ledger] ||= File.join(opts[:cache_dir], 'ledger.tsv')
   opts
@@ -96,36 +112,31 @@ end
 def unique_slug(base, seen)
   return base unless seen[base]
 
-  n = 2
-  n += 1 while seen["#{base}-#{n}"]
-  "#{base}-#{n}"
+  counter = 2
+  counter += 1 while seen["#{base}-#{counter}"]
+  "#{base}-#{counter}"
+end
+
+def candidate_parts(cols)
+  case cols.size
+  when 1 then [slug_from_url(cols[0]), '-', cols[0]]
+  when 2 then [cols[0], '-', cols[1]]
+  when 3 then [cols[0], cols[1], cols[2]]
+  else
+    raise "Bad candidate line (want URL or slug[\\tregion]\\turl): #{cols.join("\t").inspect}"
+  end
 end
 
 def parse_candidate_line(line, seen)
-  cols = line.split("\t").map(&:strip)
-  case cols.size
-  when 1
-    url = cols[0]
-    slug = unique_slug(slug_from_url(url), seen)
-    region = '-'
-  when 2
-    slug = unique_slug(cols[0], seen)
-    url = cols[1]
-    region = '-'
-  when 3
-    slug = unique_slug(cols[0], seen)
-    region = cols[1]
-    url = cols[2]
-  else
-    raise "Bad candidate line (want URL or slug[\\tregion]\\turl): #{line.inspect}"
-  end
+  slug_base, region, url = candidate_parts(line.split("\t").map(&:strip))
   raise "Not a URL: #{url.inspect}" unless url.match?(%r{\Ahttps?://}i)
 
+  slug = unique_slug(slug_base, seen)
   seen[slug] = true
   { slug: slug, region: region, url: url }
 end
 
-def load_candidates(opts)
+def candidate_lines(opts)
   lines = []
   if opts[:file]
     usage!("Candidate file not found: #{opts[:file]}") unless File.file?(opts[:file])
@@ -134,8 +145,12 @@ def load_candidates(opts)
   lines.concat(opts[:urls])
   usage!('Pass at least one URL or --file') if lines.empty?
 
+  lines
+end
+
+def load_candidates(opts)
   seen = {}
-  lines.filter_map do |raw|
+  candidate_lines(opts).filter_map do |raw|
     line = raw.strip
     next if line.empty? || line.start_with?('#')
 
@@ -161,6 +176,34 @@ def request(uri, accept: nil, insecure: false)
   http_client(uri, insecure: insecure).request(req)
 end
 
+def empty_follow(attrs)
+  {
+    chain: attrs.fetch(:chain),
+    final_url: attrs.fetch(:current),
+    status: attrs[:status],
+    body: attrs[:body],
+    error: attrs[:error],
+    ssl_note: attrs[:ssl_note],
+    insecure: attrs.fetch(:insecure, false)
+  }
+end
+
+def follow_ssl_retry(url, max, error)
+  retried = follow(url, insecure: true, max: max)
+  retried[:ssl_note] = "ssl_insecure_retry: #{error.message[0, 80]}"
+  retried
+end
+
+def handle_follow_response(res, chain, current)
+  status = res.code.to_i
+  chain << "#{status}:#{current}"
+  if res.is_a?(Net::HTTPRedirection) && res['location']
+    return [:redirect, URI.join(current, res['location']).to_s, status, nil]
+  end
+
+  [:done, current, status, res.body.to_s]
+end
+
 def follow(url, insecure: false, max: 8)
   chain = []
   current = url
@@ -169,115 +212,139 @@ def follow(url, insecure: false, max: 8)
   ssl_note = nil
 
   max.times do
-    uri = URI(current)
     begin
-      res = request(uri, insecure: insecure)
+      res = request(URI(current), insecure: insecure)
     rescue OpenSSL::SSL::SSLError => error
-      unless insecure
-        retried = follow(url, insecure: true, max: max)
-        retried[:ssl_note] = "ssl_insecure_retry: #{error.message[0, 80]}"
-        return retried
-      end
-      return { chain: chain, final_url: current, status: nil, body: nil, error: "SSL: #{error.message}",
-               ssl_note: 'ssl_fail' }
+      return follow_ssl_retry(url, max, error) unless insecure
+
+      return empty_follow(chain: chain, current: current, error: "SSL: #{error.message}", ssl_note: 'ssl_fail')
     rescue Net::HTTPExceptions => error
       code = error.response&.code&.to_i
       chain << "#{code}:#{current}" if code
-      return { chain: chain, final_url: current, status: code, body: error.response&.body.to_s,
-               error: nil }
+      return empty_follow(chain: chain, current: current, status: code, body: error.response&.body.to_s)
     end
 
-    status = res.code.to_i
-    chain << "#{status}:#{current}"
-    if res.is_a?(Net::HTTPRedirection) && res['location']
-      current = URI.join(current, res['location']).to_s
-      next
-    end
-    body = res.body.to_s
-    break
+    state, current, status, body = handle_follow_response(res, chain, current)
+    break if state == :done
   end
 
-  { chain: chain, final_url: current, status: status, body: body, ssl_note: ssl_note, insecure: insecure }
+  empty_follow(
+    chain: chain,
+    current: current,
+    status: status,
+    body: body,
+    ssl_note: ssl_note,
+    insecure: insecure
+  )
 rescue StandardError => error
-  { chain: chain, final_url: current || url, status: nil, body: nil, error: "#{error.class}: #{error.message}" }
+  empty_follow(chain: chain, current: current || url, error: "#{error.class}: #{error.message}")
+end
+
+def feed_content_type?(content_type)
+  FEED_CT.any? { |marker| content_type.include?(marker) }
+end
+
+def feed_body?(sample)
+  sample.include?('<rss') || sample.match?(/<feed[\s>]/i)
 end
 
 def real_feed?(res, body, url)
   return false unless res.is_a?(Net::HTTPSuccess)
-  return false if url.match?(/\.(svg|png|jpg|jpeg|gif|ico|css|js)(\?|$)/i)
+  return false if url.match?(ASSET_EXT)
 
-  ct = res['content-type'].to_s.downcase
-  return false if ct.include?('image') || ct.include?('svg') || ct.include?('javascript') || ct.include?('text/css')
+  content_type = res['content-type'].to_s.downcase
+  blocked = %w[image svg javascript text/css]
+  return false if blocked.any? { |part| content_type.include?(part) }
 
   sample = body.to_s[0, 4000]
-  return true if FEED_CT.any? { |m| ct.include?(m) }
-  return true if sample.include?('<rss') || sample.match?(/<feed[\s>]/i)
+  feed_content_type?(content_type) || feed_body?(sample)
+end
 
-  false
+def fetch_once(url)
+  request(URI(url), accept: FEED_ACCEPT)
 end
 
 def fetch_feed_candidate(url)
-  res = request(URI(url), accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*')
+  res = fetch_once(url)
   body = res.body.to_s
   if res.is_a?(Net::HTTPRedirection) && res['location']
-    loc = URI.join(url, res['location']).to_s
-    res = request(URI(loc), accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*')
+    url = URI.join(url, res['location']).to_s
+    res = fetch_once(url)
     body = res.body.to_s
-    url = loc
   end
   [res, body, url]
 rescue StandardError
   [nil, '', url]
 end
 
+def link_attr(tag, name)
+  tag[/\b#{name}\s*=\s*["']([^"']+)["']/i, 1].to_s
+end
+
+def alternate_feed_url?(rel, type, href)
+  return false if href.empty?
+  return false unless rel.split(/\s+/).include?('alternate') || type.match?(/rss|atom/)
+  return false unless type.match?(/rss|atom|xml/) || href.match?(/rss|atom|feed/i)
+
+  true
+end
+
+def absolute_href(page_url, href)
+  URI.join(page_url, href).to_s
+rescue StandardError
+  nil
+end
+
 def alternate_feed_hrefs(html, page_url)
   html.to_s.scan(/<link\b[^>]*>/i).filter_map do |tag|
-    rel = tag[/\brel\s*=\s*["']([^"']+)["']/i, 1].to_s.downcase
-    type = tag[/\btype\s*=\s*["']([^"']+)["']/i, 1].to_s.downcase
-    href = tag[/\bhref\s*=\s*["']([^"']+)["']/i, 1]
-    next if href.to_s.empty?
-    next unless rel.split(/\s+/).include?('alternate') || type.match?(/rss|atom/)
-    next unless type.match?(/rss|atom|xml/) || href.match?(/rss|atom|feed/i)
+    rel = link_attr(tag, 'rel').downcase
+    type = link_attr(tag, 'type').downcase
+    href = link_attr(tag, 'href')
+    next unless alternate_feed_url?(rel, type, href)
 
-    abs = begin
-      URI.join(page_url, href).to_s
-    rescue StandardError
-      next
-    end
-    next if abs.match?(/\.(svg|png|jpg|jpeg|gif|ico|css|js)(\?|$)/i)
+    abs = absolute_href(page_url, href)
+    next if abs.nil? || abs.match?(ASSET_EXT)
 
     abs
   end.uniq
 end
 
-def probe_feeds(page_url, html)
-  found = []
-  alternate_feed_hrefs(html, page_url).each do |abs|
+def origin_of(page_url)
+  uri = URI(page_url)
+  "#{uri.scheme}://#{uri.host}"
+rescue StandardError
+  nil
+end
+
+def collect_alternate_feeds(html, page_url)
+  alternate_feed_hrefs(html, page_url).filter_map do |abs|
     res, body, final = fetch_feed_candidate(abs)
-    next unless res
+    next unless res && real_feed?(res, body, final)
 
-    found << final if real_feed?(res, body, final)
+    final
   end
-  return found.uniq if found.any?
+end
 
-  origin = begin
-    u = URI(page_url)
-    "#{u.scheme}://#{u.host}"
-  rescue StandardError
-    nil
-  end
-  return [] unless origin
-
+def collect_path_feeds(origin)
+  found = []
   FEED_PATHS.each do |path|
     res, body, final = fetch_feed_candidate("#{origin}#{path}")
-    next unless res
+    next unless res && real_feed?(res, body, final)
 
-    if real_feed?(res, body, final)
-      found << final
-      break
-    end
+    found << final
+    break
   end
-  found.uniq
+  found
+end
+
+def probe_feeds(page_url, html)
+  found = collect_alternate_feeds(html, page_url)
+  return found.uniq if found.any?
+
+  origin = origin_of(page_url)
+  return [] unless origin
+
+  collect_path_feeds(origin).uniq
 end
 
 def https_to_http?(start_url, final_url)
@@ -286,20 +353,23 @@ rescue StandardError
   false
 end
 
-def verdict_for(start_url, result)
+def verdict_notes(result)
   note = []
   note << result[:ssl_note] if result[:ssl_note]
   note << 'insecure_ssl_fetch' if result[:insecure]
+  note
+end
 
-  return ['DROP', note + ["unreachable: #{result[:error]}"], result[:body].to_s] if result[:error]
-  if result[:status].nil? || result[:status] >= 400
-    return ['DROP', note + ["http_#{result[:status] || 'nil'}"], result[:body].to_s]
-  end
-  if https_to_http?(start_url, result[:final_url])
-    return ['DROP', note + ['https_to_http_downgrade'], result[:body].to_s]
-  end
-
+def early_verdict(start_url, result, note)
   body = result[:body].to_s
+  return ['DROP', note + ["unreachable: #{result[:error]}"], body] if result[:error]
+  return ['DROP', note + ["http_#{result[:status] || 'nil'}"], body] if result[:status].nil? || result[:status] >= 400
+  return ['DROP', note + ['https_to_http_downgrade'], body] if https_to_http?(start_url, result[:final_url])
+
+  nil
+end
+
+def html_verdict(result, note, body)
   feeds = probe_feeds(result[:final_url], body)
   return ['DEFER', note + ["native_rss=#{feeds.first}"], body] if feeds.any?
   return ['DROP', note + ['error_page'], body] if body.include?('ErrorPage') || result[:final_url].include?('ErrorPage')
@@ -311,53 +381,88 @@ def verdict_for(start_url, result)
   ['BUILD', note + ["html_bytes=#{body.bytesize}"], body]
 end
 
+def verdict_for(start_url, result)
+  note = verdict_notes(result)
+  early = early_verdict(start_url, result, note)
+  return early if early
+
+  html_verdict(result, note, result[:body].to_s)
+end
+
+def print_dry_run(opts, candidates)
+  puts %w[slug region url].join("\t")
+  candidates.each { |cand| puts [cand[:slug], cand[:region], cand[:url]].join("\t") }
+  puts "cache_dir=#{opts[:cache_dir]}"
+  puts "ledger=#{opts[:ledger]}"
+  puts "count=#{candidates.size}"
+end
+
+def recon_row(cand, result, verdict, notes, body, cache_dir)
+  html_path = File.join(cache_dir, "#{cand[:slug]}.html")
+  File.write(html_path, body.to_s)
+  [
+    cand[:slug],
+    cand[:region],
+    verdict,
+    cand[:url],
+    result[:final_url],
+    html_path,
+    notes.join('; '),
+    (result[:chain] || []).join(' > ')
+  ]
+end
+
+def process_candidate(cand, cache_dir)
+  result = follow(cand[:url])
+  verdict, notes, body = verdict_for(cand[:url], result)
+  row = recon_row(cand, result, verdict, notes, body, cache_dir)
+  warn([verdict, cand[:slug], result[:final_url], notes.join('; ')].join("\t"))
+  row
+end
+
+def run_recon(opts, candidates)
+  FileUtils.mkdir_p(opts[:cache_dir])
+  mutex = Mutex.new
+  rows = []
+
+  threads = candidates.map do |cand|
+    Thread.new do
+      row = process_candidate(cand, opts[:cache_dir])
+      mutex.synchronize { rows << row }
+    end
+  end
+  threads.each(&:join)
+  rows
+end
+
+def write_ledger(path, rows)
+  rows.sort_by! { |row| [row[1], row[0]] }
+  File.open(path, 'w') do |file|
+    file.puts %w[slug region verdict start_url canonical_url html_path notes redirect_chain].join("\t")
+    rows.each { |row| file.puts row.join("\t") }
+  end
+end
+
+def summarize(opts, rows)
+  build = rows.count { |row| row[2] == 'BUILD' }
+  defer = rows.count { |row| row[2] == 'DEFER' }
+  drop = rows.count { |row| row[2] == 'DROP' }
+  puts
+  puts "LEDGER=#{opts[:ledger]}"
+  puts "CACHE_DIR=#{opts[:cache_dir]}"
+  puts "BUILD=#{build} DEFER=#{defer} DROP=#{drop}"
+end
+
 opts = parse_args(ARGV)
 candidates = load_candidates(opts)
 
 if opts[:dry_run]
-  puts %w[slug region url].join("\t")
-  candidates.each { |c| puts [c[:slug], c[:region], c[:url]].join("\t") }
-  puts "cache_dir=#{opts[:cache_dir]}"
-  puts "ledger=#{opts[:ledger]}"
-  puts "count=#{candidates.size}"
+  print_dry_run(opts, candidates)
   exit 0
 end
 
-FileUtils.mkdir_p(opts[:cache_dir])
-mutex = Mutex.new
-rows = []
+rows = run_recon(opts, candidates)
+write_ledger(opts[:ledger], rows)
+summarize(opts, rows)
 
-threads = candidates.map do |cand|
-  Thread.new do
-    result = follow(cand[:url])
-    verdict, notes, body = verdict_for(cand[:url], result)
-    html_path = File.join(opts[:cache_dir], "#{cand[:slug]}.html")
-    File.write(html_path, body.to_s)
-    row = [
-      cand[:slug],
-      cand[:region],
-      verdict,
-      cand[:url],
-      result[:final_url],
-      html_path,
-      notes.join('; '),
-      (result[:chain] || []).join(' > ')
-    ]
-    mutex.synchronize { rows << row }
-    warn([verdict, cand[:slug], result[:final_url], notes.join('; ')].join("\t"))
-  end
-end
-threads.each(&:join)
-
-rows.sort_by! { |r| [r[1], r[0]] }
-File.open(opts[:ledger], 'w') do |f|
-  f.puts %w[slug region verdict start_url canonical_url html_path notes redirect_chain].join("\t")
-  rows.each { |r| f.puts r.join("\t") }
-end
-
-puts
-puts "LEDGER=#{opts[:ledger]}"
-puts "CACHE_DIR=#{opts[:cache_dir]}"
-puts "BUILD=#{rows.count { |r| r[2] == 'BUILD' }} DEFER=#{rows.count { |r| r[2] == 'DEFER' }} DROP=#{rows.count do |r|
-  r[2] == 'DROP'
-end}"
+# rubocop:enable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/ParameterLists,Metrics/PerceivedComplexity

--- a/.agents/skills/html2rss-config/scripts/batch_recon
+++ b/.agents/skills/html2rss-config/scripts/batch_recon
@@ -1,0 +1,363 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Parallel recon for one or many candidate URLs.
+# For each candidate: follow redirects, probe first-party RSS on the exact surface,
+# cache HTML once, emit a BUILD/DEFER/DROP ledger (TSV).
+#
+# Usage (from repo root):
+#   .agents/skills/html2rss-config/scripts/batch_recon 'https://example.com/news/'
+#   .agents/skills/html2rss-config/scripts/batch_recon URL [URL ...]
+#   .agents/skills/html2rss-config/scripts/batch_recon --file candidates.tsv
+#
+# Candidate file formats (blank lines and # comments ignored):
+#   https://example.com/news/
+#   example.com	https://example.com/news/
+#   example.com	LATAM	https://example.com/news/
+#
+# Options:
+#   --cache-dir DIR   HTML + ledger directory (default: tmp/html2rss-recon)
+#   --ledger PATH     Ledger TSV path (default: CACHE_DIR/ledger.tsv)
+#   --file PATH       Read candidates from file
+#   --dry-run         Parse candidates and print plan; no network
+#
+# Exit 0 always after a completed run (including all-DROP). Exit 1 on usage/parse errors.
+
+require 'fileutils'
+require 'net/http'
+require 'openssl'
+require 'uri'
+
+UA = 'html2rss-config-batch_recon/1.0'
+FEED_PATHS = %w[
+  /feed
+  /feed.xml
+  /rss
+  /rss.xml
+  /atom.xml
+  /index.xml
+  /news/rss
+  /news/feed
+  /blog/feed
+  /blog/rss.xml
+].freeze
+FEED_CT = %w[rss+xml atom+xml application/rss application/atom].freeze
+
+def usage!(msg = nil)
+  warn(msg) if msg
+  warn(<<~USAGE)
+    Usage: batch_recon [options] URL [URL ...]
+           batch_recon [options] --file candidates.tsv
+
+    Options:
+      --cache-dir DIR   Cache + default ledger dir (default: tmp/html2rss-recon)
+      --ledger PATH     Ledger TSV (default: CACHE_DIR/ledger.tsv)
+      --file PATH       Candidate list (URL lines or slug[\\tregion]\\turl)
+      --dry-run         Print candidates only; no network
+      -h, --help        Show this help
+  USAGE
+  exit 1
+end
+
+def parse_args(argv)
+  opts = { cache_dir: 'tmp/html2rss-recon', ledger: nil, file: nil, dry_run: false, urls: [] }
+  i = 0
+  while i < argv.size
+    case argv[i]
+    when '-h', '--help' then usage!
+    when '--dry-run' then opts[:dry_run] = true
+    when '--cache-dir'
+      usage!('Missing value for --cache-dir') unless argv[i + 1]
+      opts[:cache_dir] = argv[i += 1]
+    when '--ledger'
+      usage!('Missing value for --ledger') unless argv[i + 1]
+      opts[:ledger] = argv[i += 1]
+    when '--file'
+      usage!('Missing value for --file') unless argv[i + 1]
+      opts[:file] = argv[i += 1]
+    when /^--/
+      usage!("Unknown option: #{argv[i]}")
+    else
+      opts[:urls] << argv[i]
+    end
+    i += 1
+  end
+  opts[:ledger] ||= File.join(opts[:cache_dir], 'ledger.tsv')
+  opts
+end
+
+def slug_from_url(url)
+  host = URI(url).host.to_s.delete_prefix('www.')
+  host.empty? ? 'candidate' : host
+rescue StandardError
+  'candidate'
+end
+
+def unique_slug(base, seen)
+  return base unless seen[base]
+
+  n = 2
+  n += 1 while seen["#{base}-#{n}"]
+  "#{base}-#{n}"
+end
+
+def parse_candidate_line(line, seen)
+  cols = line.split("\t").map(&:strip)
+  case cols.size
+  when 1
+    url = cols[0]
+    slug = unique_slug(slug_from_url(url), seen)
+    region = '-'
+  when 2
+    slug = unique_slug(cols[0], seen)
+    url = cols[1]
+    region = '-'
+  when 3
+    slug = unique_slug(cols[0], seen)
+    region = cols[1]
+    url = cols[2]
+  else
+    raise "Bad candidate line (want URL or slug[\\tregion]\\turl): #{line.inspect}"
+  end
+  raise "Not a URL: #{url.inspect}" unless url.match?(%r{\Ahttps?://}i)
+
+  seen[slug] = true
+  { slug: slug, region: region, url: url }
+end
+
+def load_candidates(opts)
+  lines = []
+  if opts[:file]
+    usage!("Candidate file not found: #{opts[:file]}") unless File.file?(opts[:file])
+    lines.concat(File.readlines(opts[:file], chomp: true))
+  end
+  lines.concat(opts[:urls])
+  usage!('Pass at least one URL or --file') if lines.empty?
+
+  seen = {}
+  lines.filter_map do |raw|
+    line = raw.strip
+    next if line.empty? || line.start_with?('#')
+
+    parse_candidate_line(line, seen)
+  end
+rescue RuntimeError => error
+  usage!(error.message)
+end
+
+def http_client(uri, insecure: false)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = uri.scheme == 'https'
+  http.open_timeout = 10
+  http.read_timeout = 20
+  http.verify_mode = insecure ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+  http
+end
+
+def request(uri, accept: nil, insecure: false)
+  req = Net::HTTP::Get.new(uri)
+  req['User-Agent'] = UA
+  req['Accept'] = accept || 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+  http_client(uri, insecure: insecure).request(req)
+end
+
+def follow(url, insecure: false, max: 8)
+  chain = []
+  current = url
+  body = nil
+  status = nil
+  ssl_note = nil
+
+  max.times do
+    uri = URI(current)
+    begin
+      res = request(uri, insecure: insecure)
+    rescue OpenSSL::SSL::SSLError => error
+      unless insecure
+        retried = follow(url, insecure: true, max: max)
+        retried[:ssl_note] = "ssl_insecure_retry: #{error.message[0, 80]}"
+        return retried
+      end
+      return { chain: chain, final_url: current, status: nil, body: nil, error: "SSL: #{error.message}",
+               ssl_note: 'ssl_fail' }
+    rescue Net::HTTPExceptions => error
+      code = error.response&.code&.to_i
+      chain << "#{code}:#{current}" if code
+      return { chain: chain, final_url: current, status: code, body: error.response&.body.to_s,
+               error: nil }
+    end
+
+    status = res.code.to_i
+    chain << "#{status}:#{current}"
+    if res.is_a?(Net::HTTPRedirection) && res['location']
+      current = URI.join(current, res['location']).to_s
+      next
+    end
+    body = res.body.to_s
+    break
+  end
+
+  { chain: chain, final_url: current, status: status, body: body, ssl_note: ssl_note, insecure: insecure }
+rescue StandardError => error
+  { chain: chain, final_url: current || url, status: nil, body: nil, error: "#{error.class}: #{error.message}" }
+end
+
+def real_feed?(res, body, url)
+  return false unless res.is_a?(Net::HTTPSuccess)
+  return false if url.match?(/\.(svg|png|jpg|jpeg|gif|ico|css|js)(\?|$)/i)
+
+  ct = res['content-type'].to_s.downcase
+  return false if ct.include?('image') || ct.include?('svg') || ct.include?('javascript') || ct.include?('text/css')
+
+  sample = body.to_s[0, 4000]
+  return true if FEED_CT.any? { |m| ct.include?(m) }
+  return true if sample.include?('<rss') || sample.match?(/<feed[\s>]/i)
+
+  false
+end
+
+def fetch_feed_candidate(url)
+  res = request(URI(url), accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*')
+  body = res.body.to_s
+  if res.is_a?(Net::HTTPRedirection) && res['location']
+    loc = URI.join(url, res['location']).to_s
+    res = request(URI(loc), accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*')
+    body = res.body.to_s
+    url = loc
+  end
+  [res, body, url]
+rescue StandardError
+  [nil, '', url]
+end
+
+def alternate_feed_hrefs(html, page_url)
+  html.to_s.scan(/<link\b[^>]*>/i).filter_map do |tag|
+    rel = tag[/\brel\s*=\s*["']([^"']+)["']/i, 1].to_s.downcase
+    type = tag[/\btype\s*=\s*["']([^"']+)["']/i, 1].to_s.downcase
+    href = tag[/\bhref\s*=\s*["']([^"']+)["']/i, 1]
+    next if href.to_s.empty?
+    next unless rel.split(/\s+/).include?('alternate') || type.match?(/rss|atom/)
+    next unless type.match?(/rss|atom|xml/) || href.match?(/rss|atom|feed/i)
+
+    abs = begin
+      URI.join(page_url, href).to_s
+    rescue StandardError
+      next
+    end
+    next if abs.match?(/\.(svg|png|jpg|jpeg|gif|ico|css|js)(\?|$)/i)
+
+    abs
+  end.uniq
+end
+
+def probe_feeds(page_url, html)
+  found = []
+  alternate_feed_hrefs(html, page_url).each do |abs|
+    res, body, final = fetch_feed_candidate(abs)
+    next unless res
+
+    found << final if real_feed?(res, body, final)
+  end
+  return found.uniq if found.any?
+
+  origin = begin
+    u = URI(page_url)
+    "#{u.scheme}://#{u.host}"
+  rescue StandardError
+    nil
+  end
+  return [] unless origin
+
+  FEED_PATHS.each do |path|
+    res, body, final = fetch_feed_candidate("#{origin}#{path}")
+    next unless res
+
+    if real_feed?(res, body, final)
+      found << final
+      break
+    end
+  end
+  found.uniq
+end
+
+def https_to_http?(start_url, final_url)
+  URI(start_url).scheme == 'https' && URI(final_url).scheme == 'http'
+rescue StandardError
+  false
+end
+
+def verdict_for(start_url, result)
+  note = []
+  note << result[:ssl_note] if result[:ssl_note]
+  note << 'insecure_ssl_fetch' if result[:insecure]
+
+  return ['DROP', note + ["unreachable: #{result[:error]}"], result[:body].to_s] if result[:error]
+  if result[:status].nil? || result[:status] >= 400
+    return ['DROP', note + ["http_#{result[:status] || 'nil'}"], result[:body].to_s]
+  end
+  if https_to_http?(start_url, result[:final_url])
+    return ['DROP', note + ['https_to_http_downgrade'], result[:body].to_s]
+  end
+
+  body = result[:body].to_s
+  feeds = probe_feeds(result[:final_url], body)
+  return ['DEFER', note + ["native_rss=#{feeds.first}"], body] if feeds.any?
+  return ['DROP', note + ['error_page'], body] if body.include?('ErrorPage') || result[:final_url].include?('ErrorPage')
+  return ['BUILD', note + ['thin_html_needs_botasaurus'], body] if body.strip.empty? || body.bytesize < 800
+  if body.match?(/cf-browser-verification|just a moment|access denied|captcha/i) && body.bytesize < 50_000
+    return ['BUILD', note + ['possibly_blocked_html'], body]
+  end
+
+  ['BUILD', note + ["html_bytes=#{body.bytesize}"], body]
+end
+
+opts = parse_args(ARGV)
+candidates = load_candidates(opts)
+
+if opts[:dry_run]
+  puts %w[slug region url].join("\t")
+  candidates.each { |c| puts [c[:slug], c[:region], c[:url]].join("\t") }
+  puts "cache_dir=#{opts[:cache_dir]}"
+  puts "ledger=#{opts[:ledger]}"
+  puts "count=#{candidates.size}"
+  exit 0
+end
+
+FileUtils.mkdir_p(opts[:cache_dir])
+mutex = Mutex.new
+rows = []
+
+threads = candidates.map do |cand|
+  Thread.new do
+    result = follow(cand[:url])
+    verdict, notes, body = verdict_for(cand[:url], result)
+    html_path = File.join(opts[:cache_dir], "#{cand[:slug]}.html")
+    File.write(html_path, body.to_s)
+    row = [
+      cand[:slug],
+      cand[:region],
+      verdict,
+      cand[:url],
+      result[:final_url],
+      html_path,
+      notes.join('; '),
+      (result[:chain] || []).join(' > ')
+    ]
+    mutex.synchronize { rows << row }
+    warn([verdict, cand[:slug], result[:final_url], notes.join('; ')].join("\t"))
+  end
+end
+threads.each(&:join)
+
+rows.sort_by! { |r| [r[1], r[0]] }
+File.open(opts[:ledger], 'w') do |f|
+  f.puts %w[slug region verdict start_url canonical_url html_path notes redirect_chain].join("\t")
+  rows.each { |r| f.puts r.join("\t") }
+end
+
+puts
+puts "LEDGER=#{opts[:ledger]}"
+puts "CACHE_DIR=#{opts[:cache_dir]}"
+puts "BUILD=#{rows.count { |r| r[2] == 'BUILD' }} DEFER=#{rows.count { |r| r[2] == 'DEFER' }} DROP=#{rows.count do |r|
+  r[2] == 'DROP'
+end}"

--- a/lib/html2rss/configs/akorda.kz/events.yml
+++ b/lib/html2rss/configs/akorda.kz/events.yml
@@ -10,7 +10,7 @@ channel:
   ttl: 360
 selectors:
   items:
-    selector: '.card h3 a'
+    selector: ".card h3 a"
     enhance: false
   title:
     extractor: text

--- a/lib/html2rss/configs/akorda.kz/events.yml
+++ b/lib/html2rss/configs/akorda.kz/events.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - news
+channel:
+  url: https://www.akorda.kz/en/events
+  language: en
+  time_zone: Asia/Almaty
+  ttl: 360
+selectors:
+  items:
+    selector: '.card h3 a'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/angop.ao/noticias.yml
+++ b/lib/html2rss/configs/angop.ao/noticias.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+    - civic
+channel:
+  url: https://www.angop.ao/
+  language: pt
+  time_zone: Africa/Luanda
+  ttl: 360
+selectors:
+  items:
+    selector: 'h2 a[href*="/noticias/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/caricom.org/news.yml
+++ b/lib/html2rss/configs/caricom.org/news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - news
+channel:
+  url: https://caricom.org/
+  language: en
+  time_zone: America/Jamaica
+  ttl: 360
+selectors:
+  items:
+    selector: a.eael-grid-post-link
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/cepal.org/press-releases.yml
+++ b/lib/html2rss/configs/cepal.org/press-releases.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - research
+channel:
+  url: https://www.cepal.org/en/list/cepal_pr
+  language: en
+  time_zone: America/Santiago
+  ttl: 360
+selectors:
+  items:
+    selector: 'h4 a[href*="/en/pressreleases/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/cplp.org/noticias.yml
+++ b/lib/html2rss/configs/cplp.org/noticias.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - news
+channel:
+  url: https://www.cplp.org/
+  language: pt
+  time_zone: Europe/Lisbon
+  ttl: 360
+selectors:
+  items:
+    selector: 'ul.news-to-show-list a[href*="/noticias/noticias-detalhe/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/forumsec.org/publications.yml
+++ b/lib/html2rss/configs/forumsec.org/publications.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - news
+channel:
+  url: https://forumsec.org/publications
+  language: en
+  time_zone: Pacific/Fiji
+  ttl: 360
+selectors:
+  items:
+    selector: 'a.card__image[href^="/publications/"][aria-label]'
+    enhance: false
+  title:
+    extractor: attribute
+    attribute: aria-label
+  url:
+    extractor: href

--- a/lib/html2rss/configs/kompas.com/nasional.yml
+++ b/lib/html2rss/configs/kompas.com/nasional.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+    - civic
+channel:
+  url: https://nasional.kompas.com/
+  language: id
+  time_zone: Asia/Jakarta
+  ttl: 360
+selectors:
+  items:
+    selector: '.articleList a[href*="/read/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/nigerianstat.gov.ng/news.yml
+++ b/lib/html2rss/configs/nigerianstat.gov.ng/news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - research
+channel:
+  url: https://nigerianstat.gov.ng/
+  language: en
+  time_zone: Africa/Lagos
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[href*="/news/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/pib.gov.in/press-releases.yml
+++ b/lib/html2rss/configs/pib.gov.in/press-releases.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - news
+channel:
+  url: https://www.pib.gov.in/AllRel.aspx?reg=3&lang=1
+  language: en
+  time_zone: Asia/Kolkata
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[href*="PressReleaseDetail.aspx"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href


### PR DESCRIPTION
## Summary
- Ships **9 Faraday** curated configs filling remaining Global South holes (LATAM, Lusophone Africa, West Africa civic, SE/South Asia, Caribbean, Pacific, Central Asia).
- Probe-first campaign (~27 surfaces): native RSS → defer; 403/SSL/WAF/empty JS → drop; one Botasaurus retry for CBE then drop.
- Zero-coverage regions (LATAM / Caribbean / Pacific / Central Asia) are no longer empty.

### Accepted
| Config | Region | Notes |
|--------|--------|-------|
| `cepal.org/press-releases.yml` | LATAM | ECLAC press list |
| `angop.ao/noticias.yml` | Lusophone | Angola press agency |
| `cplp.org/noticias.yml` | Lusophone | CPLP noticias |
| `nigerianstat.gov.ng/news.yml` | West Africa | NBS news |
| `kompas.com/nasional.yml` | SE Asia | Nasional category |
| `pib.gov.in/press-releases.yml` | South Asia | English AllRel |
| `caricom.org/news.yml` | Caribbean | Homepage EAEL grid |
| `forumsec.org/publications.yml` | Pacific | PIF publications |
| `akorda.kz/events.yml` | Central Asia | Presidency events |

### Deferred (native RSS)
- `jeuneafrique.com` (`/feed/`), `aps.sn` (`/feed/`), `bceao.int` (`/rss.xml`)
- `tse.jus.br` (`/rss`), `opais.co.mz` (`/feed/`), `asean.org` (`/feed/`)

### Dropped (evidence)
- `mercosur.int` / `oas.org` — HTTP 403
- `caf.com` / `inecnigeria.org` / `bank-of-algeria.dz` — TLS/privacy errors (Faraday + Botasaurus)
- `iadb.org` / `bps.go.id` / `ine.mx` — 404 or empty
- `jornaldeangola.ao` — SPA shell, 0 anchors via Botasaurus
- `cbe.org.eg` — Botasaurus got usable HTML once, live feed returned WAF “Request Rejected” (one retry then drop)
- Arab League / SAMA / BKAM communiqués — unreachable, blocked, or no item list in HTML

## Test plan
- [x] `scripts/check_config` for each accepted file (validate + feed, items > 0)
- [x] Focused Faraday fetch: one rspec boot, 9 `--example` flags → 126 examples, 0 failures
- [x] `make validate` (110 configs)
- [x] `make test` (1120 examples, 0 failures)
- Chrome MCP: not used (cached HTML + Botasaurus sufficient)
- Fetch specs matched core CLI behavior for all 9 Faraday configs