### PR TITLE
feat(configs): Africa depth + GS batch (8 accepts)

### DIFF
--- a/.agents/skills/html2rss-config/SKILL.md
+++ b/.agents/skills/html2rss-config/SKILL.md
@@ -50,6 +50,8 @@ Run from repo root. Prefer these over ad‑hoc CLI glue:
 
 | Script                                                       | Purpose                                                                                                                                                                 |
 | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`scripts/batch_recon`](scripts/batch_recon)                 | Parallel redirect + RSS + HTML cache → `BUILD`/`DEFER`/`DROP` ledger (`--file` TSV or URL args).                                                                        |
+| [`scripts/analyze_html`](scripts/analyze_html)               | Selector hints from cached HTML / ledger (`--from-ledger`). No network.                                                                                                 |
 | [`scripts/probe_rss`](scripts/probe_rss)                     | First-party RSS probe (HTML `rel=alternate` then path guesses). Exit `0` = none; `3` = found (consider drop). Under `set -e`, check `$?` — do not treat `3` as failure. |
 | [`scripts/check_config`](scripts/check_config)               | `validate` + `feed` (fail on 0 items); optional `--fetch` / `--botasaurus`. Resolves CLI via PATH or sibling `../html2rss`.                                             |
 | [`scripts/register_botasaurus`](scripts/register_botasaurus) | Idempotent sorted add to `spec/support/botasaurus_fetch_configs.rb`.                                                                                                    |
@@ -57,6 +59,8 @@ Run from repo root. Prefer these over ad‑hoc CLI glue:
 Examples:
 
 ```bash
+.agents/skills/html2rss-config/scripts/batch_recon --cache-dir tmp/html2rss-recon --file candidates.tsv
+.agents/skills/html2rss-config/scripts/analyze_html --from-ledger tmp/html2rss-recon/ledger.tsv
 .agents/skills/html2rss-config/scripts/probe_rss 'https://example.com/news/'
 .agents/skills/html2rss-config/scripts/check_config domain/file.yml
 .agents/skills/html2rss-config/scripts/check_config domain/file.yml --fetch --botasaurus

--- a/lib/html2rss/configs/aps.dz/national-news.yml
+++ b/lib/html2rss/configs/aps.dz/national-news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+    - civic
+channel:
+  url: https://www.aps.dz/en
+  language: en
+  time_zone: Africa/Algiers
+  ttl: 360
+selectors:
+  items:
+    selector: 'a[href*="/en/algeria/national-news/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/dirco.gov.za/media-statements.yml
+++ b/lib/html2rss/configs/dirco.gov.za/media-statements.yml
@@ -10,7 +10,7 @@ channel:
   ttl: 360
 selectors:
   items:
-    selector: 'div.pgafu-post-grid-content h2 a'
+    selector: "div.pgafu-post-grid-content h2 a"
     enhance: false
   title:
     extractor: text

--- a/lib/html2rss/configs/dirco.gov.za/media-statements.yml
+++ b/lib/html2rss/configs/dirco.gov.za/media-statements.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - news
+channel:
+  url: https://dirco.gov.za/media-statements/
+  language: en
+  time_zone: Africa/Johannesburg
+  ttl: 360
+selectors:
+  items:
+    selector: 'div.pgafu-post-grid-content h2 a'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/news24.com/top-stories.yml
+++ b/lib/html2rss/configs/news24.com/top-stories.yml
@@ -9,7 +9,7 @@ channel:
   ttl: 180
 selectors:
   items:
-    selector: 'a.article-item__title'
+    selector: "a.article-item__title"
     enhance: false
   title:
     extractor: text

--- a/lib/html2rss/configs/news24.com/top-stories.yml
+++ b/lib/html2rss/configs/news24.com/top-stories.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+channel:
+  url: https://www.news24.com/
+  language: en
+  time_zone: Africa/Johannesburg
+  ttl: 180
+selectors:
+  items:
+    selector: 'a.article-item__title'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/philstar.com/nation.yml
+++ b/lib/html2rss/configs/philstar.com/nation.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+channel:
+  url: https://www.philstar.com/nation
+  language: en
+  time_zone: Asia/Manila
+  ttl: 360
+selectors:
+  items:
+    selector: 'h2 a[href*="/nation/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/sacu.int/news.yml
+++ b/lib/html2rss/configs/sacu.int/news.yml
@@ -10,7 +10,7 @@ channel:
   ttl: 360
 selectors:
   items:
-    selector: '.card'
+    selector: ".card"
     enhance: false
   title:
     selector: h3

--- a/lib/html2rss/configs/sacu.int/news.yml
+++ b/lib/html2rss/configs/sacu.int/news.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - news
+channel:
+  url: https://www.sacu.int/news/
+  language: en
+  time_zone: Africa/Windhoek
+  ttl: 360
+selectors:
+  items:
+    selector: '.card'
+    enhance: false
+  title:
+    selector: h3
+  url:
+    selector: 'a[href*="/articles/latest-news/"]'
+    extractor: href

--- a/lib/html2rss/configs/tap.info.tn/politics.yml
+++ b/lib/html2rss/configs/tap.info.tn/politics.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - news
+    - civic
+strategy: botasaurus
+
+channel:
+  url: https://www.tap.info.tn/en
+  language: en
+  time_zone: Africa/Tunis
+  ttl: 360
+request:
+  botasaurus:
+    wait_for_selector: 'td.NewsItemHeadline a'
+    wait_timeout_seconds: 20
+selectors:
+  items:
+    selector: 'td.NewsItemHeadline a'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/tap.info.tn/politics.yml
+++ b/lib/html2rss/configs/tap.info.tn/politics.yml
@@ -12,11 +12,11 @@ channel:
   ttl: 360
 request:
   botasaurus:
-    wait_for_selector: 'td.NewsItemHeadline a'
+    wait_for_selector: "td.NewsItemHeadline a"
     wait_timeout_seconds: 20
 selectors:
   items:
-    selector: 'td.NewsItemHeadline a'
+    selector: "td.NewsItemHeadline a"
     enhance: false
   title:
     extractor: text

--- a/lib/html2rss/configs/tralac.org/news.yml
+++ b/lib/html2rss/configs/tralac.org/news.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - civic
+    - research
+channel:
+  url: https://www.tralac.org/news.html
+  language: en
+  time_zone: Africa/Johannesburg
+  ttl: 360
+selectors:
+  items:
+    selector: 'h3 a[href*="/news/article/"]'
+    enhance: false
+  title:
+    extractor: text
+  url:
+    extractor: href

--- a/lib/html2rss/configs/www.gob.mx/profeco-prensa.yml
+++ b/lib/html2rss/configs/www.gob.mx/profeco-prensa.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/html2rss/html2rss/refs/heads/master/schema/html2rss-config.schema.json
+directory:
+  topics:
+    - consumer
+    - civic
+channel:
+  url: https://www.gob.mx/profeco/es/archivo/prensa
+  language: es
+  time_zone: America/Mexico_City
+  ttl: 360
+selectors:
+  items:
+    selector: article
+    enhance: false
+  title:
+    selector: h2
+  url:
+    selector: 'a.small-link[href*="/profeco/prensa/"]'
+    extractor: href

--- a/spec/support/botasaurus_fetch_configs.rb
+++ b/spec/support/botasaurus_fetch_configs.rb
@@ -19,6 +19,7 @@ module BotasaurusFetchConfigs
     panapress.com/latest.yml
     stackoverflow.com/hot_network_questions.yml
     support.apple.com/en_gb_ht201222.yml
+    tap.info.tn/politics.yml
     theeastafrican.co.ke/news.yml
     thoughtworks.com/insights.yml
     who.int/news.yml


### PR DESCRIPTION
## Summary

- **8 accepted configs** deepening Africa / Maghreb / LATAM / SE Asia after rebasing onto master (post-#312). SADC / ISS / Ahram already landed in #312 — not re-shipped.
- Adds `batch_recon` + `analyze_html` skill scripts and `reference/batch.md` for campaign workflow.
- Branched from master (did **not** stack on open #313); #313 may still add CARICOM/Akorda/etc.

## Accepted

| Path | Region | Strategy |
|------|--------|----------|
| `sacu.int/news.yml` | AFR-bloc | Faraday |
| `tralac.org/news.yml` | AFR-trade | Faraday |
| `news24.com/top-stories.yml` | AFR-news | Faraday |
| `dirco.gov.za/media-statements.yml` | AFR-civic | Faraday |
| `aps.dz/national-news.yml` | MENA/Maghreb | Faraday |
| `tap.info.tn/politics.yml` | MENA/Maghreb | Botasaurus |
| `www.gob.mx/profeco-prensa.yml` | LATAM | Faraday |
| `philstar.com/nation.yml` | SE Asia | Faraday |

## Deferred (native RSS this run)

AU (`/en/rss.xml`), EAC press feed, PAP rss, itweb.africa, techcentral, mg.co.za atom, theeastafrican (already on master via #312), dailymaverick `dmrss`, comesa category feed, cofece feed, CNE feed, gov.za/sanews/kenya pres/CBK/NEMA/NCC, inmetro, namibia NBC, Zambia Daily Mail, …

## Dropped (evidence)

| Surface | Evidence |
|---------|----------|
| morocco-map, ph-psa | HTTP 403 |
| vn-gso | connect timeout |
| ahram (first pass) | Net::ReadTimeout — later rebuilt OK then **superseded by #312** |
| PIB Hindi/EN, ENACOM | Botasaurus **504** after one retry (`wait_timeout_seconds` ≤ 20) |
| UNECA stories, BCN, BCB | Thin/empty HTML after Botasaurus |
| argentina-boletin | No article list (section ingress only) |
| india-powermin, th-nso | Thin / wrong redirect target |
| Top-up probes (ECOWAS/IGAD/treasury/… ) | 404/403/526 |

Known #313 DROP list (Mercosur/OAS/CAF/CBE/…) was not re-burned.

## Timing / process wins

| Phase | Wall-clock | Notes |
|-------|------------|-------|
| 0 `batch_recon` (40) | **374s** | BUILD=24 DEFER=12 DROP=4 |
| Extra + DIRCO recon | **~55s** | ahram/DIRCO |
| Parallel `check_config` | **~12s** | Faraday group |
| rspec Faraday multi-`--example` | **~15s** | one boot |
| rspec Botasaurus lane | **~21s** | TAP |
| `make validate` + `make test` | **~2s** | 115 configs; 1170 examples |

**Wins:** parallel recon; cache-authored selectors; multi-`--example` rspec; Botasaurus serialize + hard ≤20s/one-retry; gate once at end; skipped P3 topic fills when A–E BUILD queue was large.

## Test plan

- [x] `scripts/check_config` on all 8 accepts (items > 0)
- [x] Focused fetch: Faraday multi-`--example` + Botasaurus TAP
- [x] `make validate` (115 configs)
- [x] `make test` (non-fetch, 0 failures)
- [x] `register_botasaurus tap.info.tn/politics.yml`

## Residual risks

- **Overlap with #313:** if #313 still open, rebase/merge carefully (this PR already includes #312 Africa set on master).
- **News24 homepage** may drift / mix brandstory; prefer category URL later if noisy.
- **TAP** depends on Botasaurus; SSL breaks Faraday.
- **tralac** redirects through HTTP intermediates in recon notes — Faraday currently OK on final HTTPS URL.
- Selector drift on DIRCO Elementor grid / SACU cards.

## Chrome MCP / fetch vs core

- **Chrome MCP:** not needed (HTML cache + Botasaurus sufficient). user-html2rss MCP was in error state — used CLI path.
- **Fetch vs core:** focused fetch matched `html2rss feed` / `check_config` for all accepts after `www.gob.mx` folder fix.